### PR TITLE
feat: mutation-test apps on Ruby < 3.4 via external --test-command (#27, Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **`--test-command` external backend** (#27) — mutation-test apps pinned to Ruby
+  < 3.4. Mutineer stays on ≥ 3.4 but runs your suite as a subprocess in the app's
+  own runtime via `--test-command "bundle exec rails test %{files}"` (`%{files}`
+  expands to the `--test` paths; env is inherited). The mutant is applied on disk
+  with crash-safe backup/restore (self-heals a hard-killed run on next startup); a
+  smoke check aborts before scoring if the unmutated suite isn't green. This path
+  is reload-only, serial (`--jobs` forced to 1), and does no coverage narrowing —
+  so its score is an upper bound, not comparable to an in-process `--rails` score
+  (Mutineer prints this caveat). Also settable as `test_command:` in `.mutineer.yml`.
+  Safe parallelism for this path is tracked in #26.
+
 ## [0.9.1] - 2026-07-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | `--jobs N` | Parallel worker count (default: processor count; `1` under `--rails`) |
 | `--verbose` | Surface the real error when a fork capture fails (alias `--debug`) |
 | `--strategy NAME` | Mutation application: `reload` whole-file (default) or `redefine` surgical (`7a`/`7b` accepted as deprecated aliases) |
+| `--test-command CMD` | Run the suite as a subprocess in the app's own runtime (for apps on Ruby < 3.4); `CMD` must contain `%{files}`. See [Apps on Ruby < 3.4](#apps-on-ruby--34) |
 | `--format human\|json\|html` | Report format (default: human; `html` is a self-contained file) |
 | `--output FILE` | Write the report to FILE instead of stdout |
 | `--dry-run` | List candidate mutations without executing (honors suppression) |
@@ -102,6 +103,40 @@ Add Mutineer to your Gemfile's test group:
 ```ruby
 gem "mutineer", group: :test, require: false
 ```
+
+### Apps on Ruby < 3.4
+
+Mutineer's own process needs Ruby ≥ 3.4 (it parses with stdlib Prism), and the
+`--rails` path above boots your app *inside Mutineer's process* — so it can't run
+against an app pinned to an older Ruby (`ruby "3.1.6"` in the Gemfile), where the
+bundle rejects 3.4.
+
+`--test-command` decouples the two: Mutineer stays on ≥ 3.4, but your suite runs
+as a **subprocess in your app's own runtime** (whatever Ruby its bundle resolves
+to). Run Mutineer with a 3.4+ Ruby and hand it the command that runs your tests:
+
+```sh
+RAILS_ENV=test mutineer run app/models/order.rb \
+  --test test/models/order_test.rb \
+  --test-command "bundle exec rails test %{files}"
+```
+
+- **`%{files}`** is required; it expands to the `--test` paths as separate
+  arguments (a path with a space stays one argument — there is no shell).
+- **Environment** is inherited by the subprocess, so set it on the Mutineer
+  command (e.g. the leading `RAILS_ENV=test` above). Don't put `KEY=val` inside
+  `--test-command`.
+
+Tradeoffs (Phase 1) — this path is correct but not free:
+
+- **Slower:** your app re-boots for every mutant (no shared boot yet).
+- **No coverage narrowing:** every mutant runs the *full* `--test` set, so the
+  score is an **upper bound and not comparable to an in-process (`--rails`)
+  score** — uncovered mutants count as survivors, and an infrastructure failure
+  is scored as a kill. Mutineer prints this caveat on every run and aborts up
+  front (a "smoke check") if your unmutated suite isn't green.
+- **Reload strategy only** (`--strategy redefine` is rejected on this path) and
+  **serial** (`--jobs` is forced to 1 — safe parallelism is tracked in #26).
 
 ## Suppressing equivalent mutants
 
@@ -166,7 +201,9 @@ walking up). CLI flags override config; config overrides defaults.
 
 Sources are positional CLI arguments and test files come from `--test`; the
 config file accepts these keys: `operators`, `threshold`, `jobs`, `only`,
-`require` (extra files to load before mutating), and `boot`/`rails`.
+`require` (extra files to load before mutating), `boot`/`rails`, and
+`test_command` (the external-runtime suite command — see
+[Apps on Ruby < 3.4](#apps-on-ruby--34)).
 
 ```yaml
 # .mutineer.yml

--- a/docs/plans/issue-27-ruby-lt-3.4.md
+++ b/docs/plans/issue-27-ruby-lt-3.4.md
@@ -1,0 +1,610 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+issue: 27
+title: "feat: run mutation tests against Ruby < 3.4 apps (decouple tool runtime from target bundle)"
+depth: deep
+created: 2026-07-01
+---
+
+# feat: Mutation-test projects pinned to Ruby < 3.4
+
+**Issue:** #27 · **Related:** #26 (DB-isolated parallel workers), #11 (one-boot multi-source), #12 (why jobs=1), #19 (fork + AR)
+
+---
+
+## What / Why / How (plain language)
+
+**What.** Right now the tool cannot be run at all against a Rails app that is
+pinned to an older Ruby (3.1, 3.2, 3.3). A large share of production Rails apps
+are exactly that — and those mature, high-stakes codebases are where mutation
+testing pays off most. So the users who would benefit most are the ones locked
+out.
+
+**Why it's locked out.** The tool's documented Rails workflow boots the target
+app *inside the tool's own Ruby process*. That forces the tool's Ruby and the
+app's Ruby to be one and the same. Because the tool needs Ruby 3.4+ (it uses a
+parser that only ships with 3.4) and the app's `Gemfile` says "use Ruby 3.1",
+there is no single Ruby where both are happy. The 3.4 floor is effectively a
+demand on the *customer's app*, not just on our tool.
+
+**How we fix it.** Stop making the tool's Ruby be the app's Ruby. The tool
+keeps running on 3.4+, but the app's tests run in a *separate process* under the
+app's own Ruby and bundle. We ship this in two steps:
+
+- **Phase 1 — quick unblock.** Let the user hand us the exact command that runs
+  their tests (e.g. `bundle exec rails test <files>`). We apply one mutation to
+  the file on disk, run that command in the app's runtime, read pass/fail, put
+  the file back. Slower (the app re-boots per mutant) but it works on any Ruby
+  today.
+- **Phase 2 — fast version.** A long-lived helper process runs *inside the app's
+  bundle*, boots the app once, and answers "run the tests for this mutant"
+  requests from the tool over a pipe. This restores today's one-boot speed, and
+  it is the same machinery issue #26 needs to run workers in parallel safely, so
+  the two efforts converge.
+
+**Glossary.** *Mutant* = one small deliberate change to the source (e.g. flip
+`>` to `>=`). *Killed* = the test suite failed on the mutant (good — the tests
+caught it). *Survived* = the suite still passed (a gap in the tests).
+
+---
+
+## Problem Frame
+
+Two distinct couplings force tool-Ruby == app-Ruby today:
+
+1. **Prism-stdlib floor.** `mutineer.gemspec:17` sets `required_ruby_version
+   ">= 3.4"` because the tool parses with stdlib Prism, bundled only from Ruby
+   3.4. This pins the *tool source* to 3.4+.
+2. **In-process app boot (the real blocker).** `Runner.execute` (`lib/mutineer/runner.rb:47-61`)
+   does `require config.boot` (e.g. `config/environment`) in the tool's own VM,
+   then forks per mutant and runs the covering tests in-process via
+   `TestRunners.for(framework).run` (`runner.rb:287`). Booting the app in the
+   tool's VM means Bundler enforces the app's `Gemfile` ruby pin on the tool
+   process — so `ruby '3.1.6'` and the tool's ≥3.4 requirement can never both be
+   satisfied at once.
+
+Coupling (2) is the blocker: even if Prism were available on 3.1, the tool
+*source* would still have to load under the app's 3.1 bundle. The fix is to run
+the target suite in a **separate process** under the app's own runtime, and keep
+the tool on 3.4+ where Prism lives. Coupling (1) then stops mattering because the
+tool never enters the app's bundle.
+
+**Non-goal (this issue):** lowering the tool's own Ruby floor below 3.4 via the
+`prism` gem (issue direction 3). Once the runtime is decoupled it buys nothing —
+the tool stays on 3.4 by choice, not necessity. Recorded under Deferred.
+
+---
+
+## Requirements
+
+- **R1.** A user on a Rails app pinned to Ruby 3.1–3.3 can run a full mutation
+  audit and get correct kill/survive verdicts. *(Phase 1)*
+- **R2.** The tool process itself continues to require Ruby ≥ 3.4; the app's
+  suite runs under whatever Ruby the user's test command resolves to. *(Phase 1)*
+- **R3.** A user-supplied `--test-command` (and `.mutineer.yml` key) runs the
+  target suite as a subprocess, with an explicit placeholder for the test files
+  to run. Framework-agnostic — the command is opaque to the tool. *(Phase 1)*
+- **R4.** Subprocess exit status maps to a verdict without silently
+  misclassifying infrastructure failures as "killed". *(Phase 1)*
+- **R5.** A mutation applied on disk is **always restored**, including after
+  SIGKILL/timeout/crash — the user's working tree is never left mutated. *(Phase 1)*
+- **R6.** Phase 1 is opt-in and safe-by-default: absent `--test-command`, current
+  in-process behavior is unchanged. A clear error fires when the flag is set but
+  malformed. *(Phase 1)*
+- **R7.** The external path documents its known tradeoffs (per-mutant boot cost;
+  no coverage-narrowing; **score not comparable to the in-process score**; reload
+  strategy only; serial until #26). *(Phase 1)*
+- **R8.** *Spike:* prove the tool (3.4) can drive a persistent worker process
+  under the app's bundle (3.1) that boots the app once, runs one mutant's covering
+  test, and returns the correct verdict over IPC. *(Phase 2 gate)*
+- **R9.** The daemon backend restores one-boot speed and preserves coverage-based
+  test selection, and its design is compatible with #26's per-worker DB isolation
+  (one design serves both). *(Phase 2)*
+- **R10.** All parsing/mutation/Prism work stays on the 3.4 tool side; the app-side
+  worker receives ready-to-`load` text and never needs Prism. *(Phase 2)*
+
+Repo constraints (all phases): zero runtime dependencies, no `eval`, Prism +
+stdlib only. See `MEMORY.md` conventions.
+
+---
+
+## Key Technical Decisions
+
+**KTD-1 — Materialize the mutant on disk for the external path (not in-process `load`).**
+The current model applies a mutant by `load`-ing mutated text into the *tool's*
+running VM inside a fork (`Isolation.apply_whole_file`, `runner.rb:285`). A
+separate `bundle exec` subprocess has its own VM and cannot see that `load`. So
+the external path must write the mutated source to the **real file path**, run
+the command, then restore the original. This is the reload (whole-file) strategy
+expressed on disk instead of via in-process `load`.
+
+**KTD-2 — Backup-and-restore with defense in depth (R5).** On-disk mutation is
+the one genuinely dangerous new behavior: a crash mid-run could leave a user's
+source file mutated. Mirror the existing orphan-sweep discipline
+(`Runner.sweep_orphans`, `runner.rb:230`):
+- Before mutating file `F`, copy original bytes to a sibling backup
+  (`F` + a mutineer suffix) *and* hold them in memory.
+- Restore in an `ensure` around each mutant.
+- Parent sweeps/normalizes any leftover backups before and after the whole run
+  (SIGKILL skips `ensure`, exactly as it does for tempfiles today).
+- On startup, if a backup exists for a source file, restore it before doing
+  anything (self-heal from a prior hard kill).
+- Only one mutant is in flight per file at a time on this path (serial — see
+  KTD-5), so backup collisions cannot occur.
+
+**KTD-3 — Exit-status → verdict mapping (same as in-process, coarser), with a
+smoke-check guard (R4).** In-process today: child exit `0=survived, 1=killed,
+2=error`, timeout via the parent monitor (`Isolation.decode`, `isolation.rb:205-212`).
+A normal test command uses the **same** direction — the suite exits `0` when it
+**passes** and non-zero when it **fails** — so suite-passes ⇒ **survived**,
+suite-fails ⇒ **killed**, exactly like the in-process backend
+(`TestRunners.run` returns `0=all-passed`; `isolation.rb:207` maps `0→survived`).
+This is **not an inversion**; it is the same mapping at **coarser granularity** —
+the external path loses the `error`/`timeout` distinction a dedicated exit 2 gives
+in-process.
+
+| Subprocess outcome | Verdict |
+|---|---|
+| exit 0 (suite passed) | **survived** |
+| stable "suite failed to run" code (where the framework emits one) | **error** (excluded) |
+| other exit non-zero (suite failed) | **killed** |
+| exceeds timeout (parent kills it) | **killed (timeout)** |
+
+Two failure-transparency gaps this coarseness opens, and how the plan closes them:
+- **Infra failure scored as "killed" (score inflates *upward*).** A DB drop,
+  LoadError, OOM (137), or wrong `RAILS_ENV` also exits non-zero and is
+  indistinguishable from a real kill. Mitigations: (a) a **smoke check** (KTD-3a)
+  runs the command once against the unmutated file at startup and aborts if the
+  clean suite is not green — env broken, not tests strong; (b) where the framework
+  emits a stable "suite failed to run" code distinct from "tests failed", map it to
+  `Result.error` (excluded from the denominator) not `killed`; (c) the run header
+  states the external score is an **upper bound**. Residual intermittent per-mutant
+  infra failure is an accepted Phase-1 limit (R7); Phase 2's structured IPC
+  distinguishes error from failure natively.
+- **Invalid mutants** must stay `skipped`, not fall into `killed` — see KTD-8.
+
+**KTD-3a — Smoke check, not "baseline".** The startup clean-run guard is named
+**smoke check** (or clean-run guard), deliberately *not* "baseline" — `--baseline`
+/ `lib/mutineer/baseline.rb` already means the CI regression-delta gate, an
+unrelated concept. The smoke check lives on the external backend, not in
+`baseline.rb`.
+
+**KTD-4 — `--test-command` surface and `%{files}` substitution (R3).** Add a
+CLI flag and `.mutineer.yml` key (snake_case `test_command`, following the existing
+explicit-tracking pattern in `cli.rb`, e.g. `--baseline`). The command string is a
+template turned into an **argv array** (no shell → no `eval`, no injection):
+- Tokenize the template into argv elements first.
+- The `%{files}` token expands **in place to N separate argv elements**, one per
+  test path, unescaped — there is no shell to un-quote, so a path containing a
+  space stays a single argument. It is **not** a space-joined string (the earlier
+  "space-joined, shell-safe" framing was wrong: "shell-safe" is meaningless with no
+  shell, and joining breaks a runner that expects N file args).
+- `%{files}` is **required**; if absent, error at `validate!` — do not silently
+  append, so the user always sees where the files land.
+- **Environment:** a spawned subprocess already inherits the tool's env, so
+  `RAILS_ENV=test mutineer …` reaches the child with no parsing on our side. The
+  command string is *just the command* — no leading `KEY=val` sugar to half-emulate
+  a shell. A workflow needing env scoped to only the suite gets a dedicated
+  repeatable `--env KEY=VAL` flag, deferred until a real need appears.
+
+Example: `RAILS_ENV=test mutineer run … --test-command "bundle exec rails test %{files}"`.
+
+**KTD-5 — External path is serial in Phase 1; parallel is #26's job.** Each
+subprocess boots the app and opens its own fixture transaction against the *same*
+database — the exact corruption #26 documents for `--jobs > 1`. So under
+`--test-command`, force `jobs = 1` (with a one-line notice if the user asked for
+more), same rationale as #12. Phase 2 + #26 lift this together. This keeps Phase
+1 correct-by-construction.
+
+**KTD-6 — No coverage-narrowing on the external path; reload only; score is NOT
+cross-backend-comparable (R7).** Coverage selection is built by forking the
+*booted-in-process* app and measuring each test's coverage delta
+(`CoverageMap#build_via_fork`, driven from `runner.rb:74`). The external path never
+boots in-process, so there is no coverage map: every mutant runs the **full
+`--test` set** passed as `%{files}`.
+
+This is not only a perf tradeoff — it changes the **score's meaning**. In-process,
+a mutant on a line no test exercises is `no_coverage` and **excluded** from the
+denominator (`runner.rb:267-274`); on the external path that same mutant runs the
+full suite, nothing covers it, the suite passes, and it scores **`survived`**
+(included). So identical code + tests reports a **lower** score under
+`--test-command` than in-process. Handle it honestly:
+- The run header and docs (U6) state the external score is **not comparable** to
+  the in-process score — uncovered mutants count as survivors here.
+- Report the count of mutants that ran without narrowing, so the user can reason
+  about the gap.
+- Best-effort/optional: where tool-side static analysis can prove a line
+  unreachable, still emit `no_coverage`.
+
+`--strategy redefine` (surgical in-VM `load`, `isolation.rb:107`) also cannot
+apply to a separate process — the external path is reload/whole-file only; a
+`redefine` request on this path errors clearly rather than silently degrading.
+
+**KTD-8 — Preserve the tool-side per-mutant skips on the external path (R4).**
+Two classifications currently live inside `Runner.run` (`runner.rb:255,267-274`),
+which U4 bypasses — re-apply them tool-side *before* the subprocess runs, or their
+`Result` states go unreachable and those mutants skew the score:
+- **Invalid mutant → `skipped`.** If `Parser.parse_string(mutated).errors.any?`
+  (Prism, tool-side, already computed), classify `Result.skipped` and **never write
+  the file** — otherwise the app fails to load, exits non-zero, and scores a false
+  `killed`.
+- **No-coverage → per KTD-6** (best-effort static proof; otherwise runs the full set).
+
+**KTD-7 — Phase 2 keeps Prism on the tool side (R10).** The daemon (app Ruby)
+must never need Prism. The tool (3.4) does *all* parsing, mutation, subject
+discovery, and — critically — the surgical-snippet reparse validation
+(`isolation.rb:142`), then ships the daemon either whole mutated file text or a
+ready-to-`load` wrapped snippet plus the covering test paths. The daemon only
+`load`s text and runs tests. This is what makes the decoupling total: Prism-3.4
+stays home; the app side runs on 3.1 with no new gem.
+
+---
+
+## High-Level Technical Design
+
+### Execution model: today vs Phase 1 vs Phase 2
+
+```
+TODAY (in-process, blocked on <3.4)
+┌─ tool VM (MUST be app Ruby) ─────────────────┐
+│ require config/environment  (boots Rails)    │
+│ Coverage.start; build coverage map via fork  │
+│ per mutant: fork → load(mutated) → run tests │  ← app Ruby == tool Ruby == 3.4+ required
+└──────────────────────────────────────────────┘
+
+PHASE 1 (external subprocess — unblocks <3.4, slower)
+┌─ tool VM (3.4+) ─────────────┐        ┌─ subprocess (app Ruby 3.1) ─┐
+│ parse + build mutant (Prism) │        │ bundle exec rails test <f>  │
+│ smoke check once             │        │ boots app EACH mutant       │
+│ per mutant:                  │  spawn │ exit 0 = pass, non-0 = fail │
+│   skip if invalid (KTD-8)    │───────▶│                             │
+│   swap file on disk          │◀───────┤ (verdict from exit status)  │
+│   run test-command, read exit│        └─────────────────────────────┘
+│   restore file (ensure)      │         serial (jobs=1)
+└──────────────────────────────┘         full --test set — no coverage narrowing
+
+PHASE 2 (persistent daemon — restores speed, converges with #26)
+┌─ tool VM (3.4+) ─────────────┐   IPC   ┌─ daemon (app Ruby 3.1, bundle) ─┐
+│ parse + build mutant (Prism) │ (pipe,  │ boots app ONCE                  │
+│ ship mutated text + tests ───┼────────▶│ Coverage map in-process         │
+│ read structured verdict ◀────┼─────────┤ per request: fork → load → test │
+│ (killed/survived/error/TO)   │  JSON   │ #26: fork routed to worker DB-N │
+└──────────────────────────────┘         └─────────────────────────────────┘
+```
+
+### Phase 1 per-mutant sequence
+
+```
+tool                              app subprocess (app Ruby)
+ │ skip if mutant invalid (reparse, tool-side) → Result.skipped, no write
+ │ backup original bytes of F
+ │ write mutated bytes to F
+ │ spawn [test-command, %{files}=ALL --test files] ─▶ boot app, run tests
+ │ wait (with wall-clock timeout, kill on breach)  ◀─ exit status
+ │ restore F from backup   (ensure — always runs)
+ │ map exit → survived / error / killed / timeout (KTD-3)
+ ▼ next mutant
+```
+
+---
+
+## Phased Delivery
+
+### Phase 1 — External test-command backend (ships independently, unblocks #27)
+
+Delivers R1–R7. A new execution backend selected when `--test-command` is set;
+the in-process backend is untouched when it is not.
+
+### Gate — Spike before Phase 2 (R8)
+
+A throwaway spike proving one forked worker, launched by the 3.4 tool but running
+under the app's 3.1 bundle, can: boot the app once, receive one mutant spec over
+a pipe, `load` the mutated text, run its covering test against an isolated DB, and
+return the correct kill/survive — with N=2 deterministic and matching serial.
+**Do not start Phase 2 build until the spike passes.** This spike is the natural
+merge point with #26's existing spike plan
+(`docs/plans/issue-26-db-isolated-parallel-spike.md`); run them as one.
+
+### Phase 2 — Persistent app-side worker daemon (converges with #26)
+
+Delivers R9–R10. Supersedes #26's standalone daemon design. Only planned at unit
+level after the spike gate passes — units below are directional, not yet
+implementation-ready, and will be re-planned post-spike.
+
+---
+
+## Implementation Units
+
+> Phase 1 units (U1–U6) are implementation-ready. Phase 2 units (U7–U9) are
+> directional and gated on the spike (R8); re-plan them after the spike passes.
+
+### U1. `--test-command` CLI flag, config key, and validation
+
+**Goal:** Accept an external test command from CLI and `.mutineer.yml`, validated
+and mutually consistent with existing flags.
+**Requirements:** R3, R6.
+**Dependencies:** none.
+**Files:** `lib/mutineer/cli.rb`, `lib/mutineer/config.rb`, `test/` (new
+`test/cli_test_command_test.rb` or nearest existing CLI test file).
+**Approach:** Add `o.on("--test-command CMD")` following the explicit-tracking
+pattern used for `--baseline` (`cli.rb:106`); the `.mutineer.yml` key is snake_case
+`test_command` (update `KNOWN_KEYS`/`field_for`/`coerce` in `config.rb` to match the
+existing key convention). Add a `test_command` reader on `Config` and merge
+precedence CLI > `.mutineer.yml` (mirror `--baseline`). In `validate!`: (a) reject
+an empty command; (b) reject a command missing the `%{files}` placeholder (KTD-4 —
+no silent append); (c) if `--test-command` and `--strategy redefine` are both set,
+error clearly (KTD-6); (d) if `--jobs > 1` with `--test-command`, force `1` with a
+one-line notice (KTD-5). Update the `banner`/usage text (`cli.rb:32-58`).
+**Note on (d) vs `--rails`:** `--rails` honors an explicit `--jobs N`
+(`config.rb:117-122`) because #26 gives it per-worker DB isolation to opt into. The
+external path has **no** such isolation yet, so an explicit `--jobs N` here would be
+silently corrupt — hence forced to 1, not honored. Documented so the divergence is
+a reasoned exception, not drift; revisit when #26 lands.
+**Patterns to follow:** `--baseline` explicit tracking; existing `validate!`
+warnings (`cli.rb:203-246`).
+**Test scenarios:**
+- Flag sets `config.test_command`; `.mutineer.yml` key does too; CLI overrides file.
+- Empty/whitespace command → clear error, non-zero exit, no backtrace.
+- Command without `%{files}` → clear error naming the missing placeholder.
+- `--test-command` + `--strategy redefine` → clear error naming the conflict.
+- `--test-command` + `--jobs 4` → forced to 1 with a one-line notice.
+- Absent `--test-command` → config unchanged, in-process path selected (no regression).
+
+### U2. Mutant file-swap with crash-safe backup/restore
+
+**Goal:** Apply one whole-file mutant to the real source path and guarantee
+restoration on every exit path.
+**Requirements:** R5.
+**Dependencies:** U1.
+**Files:** new `lib/mutineer/file_swap.rb` (or extend `lib/mutineer/isolation.rb`),
+`test/file_swap_test.rb`.
+**Approach:** `FileSwap.with(source_file, mutated_bytes) { ... }` — write backup
+sibling + keep original in memory, write mutated bytes, `yield`, restore from
+memory in `ensure`, delete backup. Add a `restore_orphans(source_dirs)` sweep
+(parallel to `Runner.sweep_orphans`, `runner.rb:230`) that restores any leftover
+backup at startup and after the run. Backup filename uses a fixed
+`.mutineer-backup` suffix so the sweeper can find it deterministically.
+**Patterns to follow:** `Runner.sweep_orphans` / the tempfile-orphan discipline
+(`runner.rb:118-124`, `isolation.rb:85-91`).
+**Execution note:** Start with a failing test that asserts the file is restored
+after the block raises, and after a simulated hard-kill (leftover backup on disk →
+`restore_orphans` heals it).
+**Test scenarios:**
+- Block runs → file holds mutated bytes during, original bytes after; backup gone.
+- Block raises → original bytes restored; exception propagates.
+- Leftover backup present at startup → `restore_orphans` restores original, removes backup.
+- Byte-exact restoration (frozen-string / encoding / trailing-newline preserved).
+- Covers R5. Integration: mutated content is what the subprocess actually reads (write-then-read round trip).
+
+### U3. External backend: subprocess spawn + exit-status → verdict mapping
+
+**Goal:** Run the user's command in the app runtime for one mutant and decode the
+result into a `Result`.
+**Requirements:** R3, R4.
+**Dependencies:** U1, U2.
+**Files:** new `lib/mutineer/external_backend.rb` — a distinct execution backend,
+deliberately **not** under `test_runners/`: it does spawn + timeout + verdict
+mapping, unlike the thin `.run(files)->Integer` framework adapters
+(`test_runners/minitest.rb`, `rspec.rb`). Also `lib/mutineer/result.rb` (reuse
+existing states), `test/external_backend_test.rb`.
+**Approach:** Build argv from the template (KTD-4): tokenize, then expand `%{files}`
+to **N separate argv elements** (one per path, unescaped). Spawn via the array form
+with the same wall-clock timeout + SIGKILL discipline the parent already uses
+(`Isolation.run`, `isolation.rb:57-68`) — factor that monitor so timeout handling
+is not re-implemented. Map per KTD-3: exit 0 → `Result.survived`; a stable "suite
+failed to run" code (where the framework emits one) → `Result.error`; other
+non-zero → `Result.killed`; timeout → `Result.timeout`. Capture child
+stdout/stderr; on any non-zero exit print a **one-line stderr notice by default**
+(what happened + "re-run with --verbose for output"), and surface the full captured
+output under `--verbose`.
+**Patterns to follow:** `Isolation.run` timeout/kill loop. This backend does **not**
+implement the `TestRunners.for` adapter contract (Integer 0/1, fork-only) — it is
+selected by U4's backend branch, not by framework name.
+**Test scenarios:**
+- Command exits 0 → survived; exits 1 → killed; exits 137/other non-zero → killed.
+- A path containing a space → `%{files}` yields N argv tokens, each one intact arg (not split, not joined).
+- `%{files}` absent from the template → `validate!` error (not silent append) — asserted in U1.
+- Env inheritance: `RAILS_ENV=test` set in the tool's env reaches the child; the command string carries no `KEY=val` parsing of our own.
+- Framework's stable "suite failed to run" code → `Result.error` (excluded); a genuine test failure → `Result.killed`.
+- Runaway command exceeding timeout → killed(timeout), process reaped, no zombie.
+- No `eval`, no shell string built from the file list (argv array asserted).
+- A first non-zero exit prints the one-line default notice; full output only under `--verbose`.
+
+### U4. Wire the external backend into the runner (backend selection)
+
+**Goal:** Route the run through the external backend when `--test-command` is set,
+leaving the in-process path byte-for-byte unchanged otherwise.
+**Requirements:** R1, R6.
+**Dependencies:** U2, U3.
+**Files:** `lib/mutineer/runner.rb`, `test/runner_external_test.rb`.
+**Approach:** In `Runner.execute`, branch early on `config.test_command`: skip the
+in-process boot/require and coverage-map build (`runner.rb:47-87`); build the job
+list exactly as today (subject discovery is a static Prism parse needing nothing
+loaded — see `runner.rb:100-114`). For each job, **first apply the tool-side skips
+of KTD-8** — reparse the mutated source and classify `Result.skipped` (never
+writing the file) if it fails — then run every `--test` file (full set, KTD-6)
+through U2+U3 instead of the fork+`load` path. Aggregate identically
+(`AggregateResult`). Keep `--since`, `--only`, suppression, `--fail-fast`,
+`--baseline` working — they operate on the job list, above the execution backend.
+**Patterns to follow:** the existing standalone-vs-boot branch in `Runner.execute`;
+the `Parser.parse_string(mutated).errors.any? → Result.skipped` guard at
+`runner.rb:255`; `AggregateResult` assembly (`runner.rb:145`).
+**Test scenarios:**
+- `--test-command` set → no in-process boot; verdicts match a known killed/survived fixture.
+- Invalid (non-reparsing) mutant → `Result.skipped`, file never written, excluded from the denominator (not a false `killed`).
+- `--fail-fast`, `--only`, `--since`, suppression comments still filter jobs on this path.
+- Absent `--test-command` → in-process path unchanged (regression guard on an existing boot-mode test).
+- End-to-end on a tiny fixture: 1 killed + 1 survived mutant → correct score and exit code.
+
+### U5. Smoke-check pre-flight (clean-run guard)
+
+**Goal:** Fail fast with a clear message when the unmutated suite is not green, so
+infra breakage is never scored as strong tests.
+**Requirements:** R4.
+**Dependencies:** U3, U4.
+**Files:** `lib/mutineer/external_backend.rb` (or `lib/mutineer/runner.rb`).
+Deliberately **not** `lib/mutineer/baseline.rb` — that module owns the unrelated
+`--baseline` CI delta-gate concept (KTD-3a). `test/smoke_check_test.rb`.
+**Approach:** Before running any mutant on the external path, run the command once
+against the untouched file(s). If it does not exit 0, abort with a message that (a)
+names the likely cause (env, DB, RAILS_ENV) and (b) **includes the failing
+command's captured stdout/stderr tail** — nothing else has run yet, so this is the
+best diagnostic moment. Do **not** report a score. Gated inside `execute` so
+`--dry-run` never triggers it. Always-on (no opt-out flag until a real need
+appears).
+**Test scenarios:**
+- Clean suite exits 0 → proceeds to mutants.
+- Clean suite exits non-zero → abort, clear message with captured output tail, non-zero exit, zero mutants run.
+- Message names the diagnostic direction (broken environment, not weak tests).
+- `--dry-run --test-command` → smoke check never runs (no app boot).
+- Covers R4.
+
+### U6. Docs + tradeoff disclosure
+
+**Goal:** Document the cross-runtime workflow and its Phase-1 limits so users on
+older Rubies aren't guessing (issue direction 4).
+**Requirements:** R7.
+**Dependencies:** U1–U5.
+**Files:** `README.md`, site docs (per the repo's docs/site setup), `CHANGELOG`.
+**Approach:** Add a "Ruby < 3.4 / older Rails apps" section: the `--test-command`
+recipe, the exact `%{files}` semantics (required; expands to N argv tokens), env
+via inheritance (`RAILS_ENV=test mutineer …`), and the honest tradeoffs —
+per-mutant boot cost, no coverage-narrowing (full `--test` set per mutant), the
+resulting **score is not comparable to the in-process score** (uncovered mutants
+count as survivors), reload-only, serial until #26.
+**Test scenarios:** `Test expectation: none — documentation only.`
+
+---
+
+### U7. (Phase 2, gated) Spike: tool-3.4 → app-3.1 worker over IPC
+
+**Goal:** Prove per-worker app boot + `load` + isolated-DB test under the app's
+bundle, driven by the 3.4 tool. **This is the R8 gate.**
+**Requirements:** R8.
+**Dependencies:** U1–U5 (reuse mutant generation + verdict types); merges with
+`docs/plans/issue-26-db-isolated-parallel-spike.md`.
+**Files:** throwaway spike dir (not shipped).
+**Approach:** Tool spawns a small worker script under the app bundle; worker boots
+the app once, reads one mutant spec (mutated text + covering test paths) from a
+pipe, forks, `load`s the text, routes AR to an isolated worker DB (#26), runs the
+test, writes a structured verdict back. Prove N=2 deterministic == serial.
+**Execution note:** Spike — optimize for a yes/no answer, not production shape.
+**Test scenarios:** Manual/spike: correct kill and survive on a known fixture;
+N=2 verdicts identical to serial; no cross-talk deadlocks.
+
+### U8. (Phase 2, gated) IPC protocol + daemon lifecycle
+
+**Goal:** Define the tool↔daemon message contract and spawn/health/shutdown
+lifecycle.
+**Requirements:** R9, R10.
+**Dependencies:** U7 passes.
+**Files:** TBD post-spike.
+**Approach (directional):** Newline-delimited JSON or Marshal over a pipe;
+messages carry mutated text (or ready-to-`load` wrapped snippet — KTD-7), covering
+test paths, timeout, worker-DB index. Tool owns lifecycle; daemon is stateless per
+request beyond the one-time boot. Structured verdict distinguishes
+survived/killed/error/timeout natively (fixes KTD-3's Phase-1 limitation).
+**Test scenarios:** Re-planned post-spike.
+
+### U9. (Phase 2, gated) Daemon backend + coverage selection + #26 convergence
+
+**Goal:** Production daemon backend restoring one-boot speed and coverage
+narrowing, with #26's per-worker DB isolation.
+**Requirements:** R9, R10.
+**Dependencies:** U8.
+**Files:** TBD post-spike.
+**Approach (directional):** Daemon boots once, builds the coverage map in-process
+(restores KTD-6's lost narrowing), forks per request routed to worker DB-N.
+Supersedes #26's standalone daemon. Tool stays Prism-3.4; daemon needs no Prism
+(KTD-7).
+**Test scenarios:** Re-planned post-spike.
+
+---
+
+## Scope Boundaries
+
+**In scope (Phase 1):** external `--test-command` backend, on-disk crash-safe
+mutation, exit-status verdict mapping, smoke-check guard, docs.
+
+**In scope (Phase 2, gated):** spike, IPC protocol, persistent daemon backend
+converging with #26.
+
+### Deferred to Follow-Up Work
+
+- **Coverage-narrowing on the external path.** Restored properly by the Phase 2
+  daemon (in-process coverage). Not worth reintroducing for the subprocess path.
+- **Per-mutant infra-error vs test-fail distinction on the external path.**
+  Accepted Phase-1 limitation (mitigated by the smoke-check guard); solved
+  natively by Phase 2's structured IPC verdict.
+- **`--strategy redefine` over a subprocess.** Not meaningful without a shared VM;
+  Phase 2 daemon can support surgical `load` again (KTD-7).
+
+### Outside this issue's identity
+
+- **Lowering the tool's own Ruby floor below 3.4 via the `prism` gem** (issue
+  direction 3). Runtime decoupling makes it unnecessary; the tool stays 3.4 by
+  choice. Revisit only if a concrete need appears.
+
+---
+
+## Risks & Dependencies
+
+- **R (data safety): on-disk mutation could leave a user's source mutated after a
+  hard kill.** *Mitigation:* KTD-2 defense in depth (in-memory + backup + `ensure`
+  + startup self-heal + serial-per-file). This is the highest-severity new risk;
+  U2 is test-first.
+- **R (correctness): infra failure scored as "killed" (score inflates up).**
+  *Mitigation:* KTD-3 smoke-check guard (U5) + `error`-code mapping + upper-bound
+  header; KTD-8 keeps invalid mutants `skipped`; documented residual (R7).
+- **R (correctness): external score reads lower than in-process** because uncovered
+  mutants score `survived` not `no_coverage` (KTD-6). *Mitigation:* documented
+  non-comparability + no-coverage count in the run header (U6).
+- **R (security): command injection via `--test-command`.** *Mitigation:* argv
+  array form, no shell string built from file lists, no `eval` (KTD-4, repo
+  constraint). U3 asserts argv construction.
+- **R (perf): per-mutant boot makes large audits slow.** *Accepted* for Phase 1
+  (the whole point is correctness + reach on old Ruby); Phase 2 fixes it.
+- **Dependency:** Phase 2 spike is shared with #26 — coordinate so one spike
+  answers both (`docs/plans/issue-26-db-isolated-parallel-spike.md`).
+
+---
+
+## Definition of Done
+
+**Phase 1 (shippable on its own):**
+- A Ruby 3.1–3.3 Rails app produces correct kill/survive verdicts via
+  `--test-command` (R1), with the tool process still on ≥3.4 (R2).
+- `--test-command` works from CLI and `.mutineer.yml`, validated, with clear
+  errors on conflicts (R3, R6).
+- Exit-status mapping is correct: invalid mutants stay `skipped`, a "suite failed
+  to run" code maps to `error`, and a non-green smoke check aborts before scoring
+  (R4).
+- The working tree is provably never left mutated, including after a simulated
+  hard kill (R5) — asserted by tests.
+- Tradeoffs documented (R7).
+- In-process behavior is unchanged when `--test-command` is absent (regression
+  guard green).
+
+**Phase 2 (gated on spike):**
+- Spike proves tool-3.4 → app-3.1 isolated-DB worker verdict parity with serial
+  (R8) before any build.
+- Daemon backend restores one-boot speed and coverage narrowing, no Prism on the
+  app side, converged with #26 (R9, R10).
+
+---
+
+## Verification Contract
+
+- **Unit:** U1–U5 each have the test scenarios above; feature-bearing units
+  (U2–U5) test happy path + error/edge + the data-safety/infra-error paths.
+- **Integration:** a tiny in-repo fixture (a source with one killed + one survived
+  mutant and a trivial `--test-command`) proves the external backend end-to-end
+  without needing a real Rails app in CI.
+- **Regression:** an existing boot-mode test runs unchanged with `--test-command`
+  absent, proving the in-process path is untouched.
+- **Manual (Phase 1 acceptance):** run against a real Ruby 3.1.x Rails app (the
+  issue author offered to help) and confirm verdicts match expectation.
+- **Gate:** Phase 2 build does not begin until the R8 spike passes.

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -47,6 +47,10 @@ module Mutineer
         --boot FILE          Require FILE once in the parent to boot the app env, then
                              fork per mutant (Rails apps; requires --test)
         --rails              Sugar for --boot config/environment --strategy redefine
+        --test-command CMD   Run the target suite in the app's own runtime as a
+                             subprocess (for apps on Ruby < 3.4). CMD must contain
+                             %{files} (expands to the --test paths). Env is inherited,
+                             e.g. RAILS_ENV=test mutineer run ... --test-command "..."
         --format human|json|html  Report format (default: human)
         --output FILE        Write the report to FILE instead of stdout
         --dry-run            List mutations without executing
@@ -105,6 +109,9 @@ module Mutineer
         # typed (CLI wins over the file). --baseline-epsilon is CLI-only.
         o.on("--baseline FILE") { |v| opts[:baseline] = v; explicit << :baseline }
         o.on("--baseline-epsilon FLOAT") { |v| opts[:baseline_epsilon] = v.to_f }
+        # #27: run the target suite as a subprocess in the app's OWN runtime so
+        # mutineer (Ruby >= 3.4) can mutation-test apps pinned to an older Ruby.
+        o.on("--test-command CMD") { |v| opts[:test_command] = v; explicit << :test_command }
       end
 
       begin
@@ -229,6 +236,8 @@ module Mutineer
         exit 2
       end
 
+      validate_test_command!(config) if config.test_command
+
       validate_since!(config) if config.since
       preflight_output!(config.output) if config.output
       preflight_baseline!(config.baseline) if config.baseline
@@ -248,6 +257,42 @@ module Mutineer
       end
 
       validate_paths!(config)
+    end
+
+    # #27: --test-command runs the target suite in the app's own runtime. Validate
+    # its shape up front (usage errors → exit 2) and force serial execution: each
+    # subprocess boots the app and opens its own fixture transaction against the
+    # same DB, so --jobs > 1 would corrupt results (the #12 fixture-contention
+    # hazard). Unlike --rails, this path has NO per-worker DB isolation to opt into,
+    # so an explicit --jobs N is forced to 1 rather than honored (KTD-5).
+    # Validates the --test-command configuration.
+    #
+    # @api private
+    # @param config [Mutineer::Config] run configuration.
+    # @return [void]
+    def self.validate_test_command!(config)
+      if config.test_command.strip.empty?
+        warn "mutineer: --test-command must not be empty"
+        exit 2
+      end
+      unless config.test_command.include?("%{files}")
+        warn "mutineer: --test-command must contain %{files} (where the --test paths are substituted)"
+        exit 2
+      end
+      if config.boot
+        warn "mutineer: --test-command cannot be combined with --boot/--rails " \
+             "(the external subprocess boots the app itself)"
+        exit 2
+      end
+      if config.strategy == "redefine"
+        warn "mutineer: --test-command supports only --strategy reload " \
+             "(surgical redefine needs a shared VM; the subprocess has its own)"
+        exit 2
+      end
+      return unless config.jobs > 1
+
+      warn "[mutineer] --test-command runs serially (no per-worker DB isolation yet); forcing --jobs 1."
+      config.jobs = 1
     end
 
     # --since needs a real git repo and a resolvable ref; either failure is a

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -195,6 +195,11 @@ module Mutineer
     rescue Mutineer::ParseError => e
       warn "mutineer: error reading: #{e.message}"
       exit 1
+    rescue Mutineer::SmokeCheckError => e
+      # #27: the unmutated suite isn't green under --test-command — a broken
+      # environment, not weak tests. Runtime error (exit 1), not usage (exit 2).
+      warn "mutineer: #{e.message}"
+      exit 1
     end
 
     # Flag validation: every flag/usage failure exits 2 (C7), consistent with the
@@ -421,6 +426,16 @@ module Mutineer
 
       reporter.report(out: $stdout, err: $stderr, threshold: config.threshold,
                       format: config.format, output: config.output, baseline: delta)
+
+      # #27/KTD-6: warn (stderr, so it never pollutes json/html) that an external
+      # run's score is not comparable to an in-process run — it has no coverage
+      # narrowing, so uncovered mutants count as survivors, and an infra failure is
+      # scored as a kill (upper bound).
+      if config.test_command
+        warn "[mutineer] --test-command score is an upper bound, not comparable to an " \
+             "in-process run: no coverage narrowing (uncovered mutants count as survivors) " \
+             "and an infra failure is scored as a kill."
+      end
 
       # #14: nudge toward the opt-in tier-2 operators (human report only — never
       # pollute JSON output).

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -25,13 +25,13 @@ module Mutineer
     :cache_dir, :project_root, :load_paths,
     :jobs, :format, :output, :strategy, :require_paths,
     :boot, :rails, :since, :framework, :verbose, :ignore,
-    :baseline, :baseline_epsilon, :fail_fast,
+    :baseline, :baseline_epsilon, :fail_fast, :test_command,
     keyword_init: true
   ) do
     # Config file name.
     CONFIG_FILE = ".mutineer.yml"
     # Keys accepted in .mutineer.yml (R7). `require` maps to the :require_paths field.
-    KNOWN_KEYS = %w[operators jobs threshold only require boot rails since framework verbose ignore baseline fail_fast].freeze
+    KNOWN_KEYS = %w[operators jobs threshold only require boot rails since framework verbose ignore baseline fail_fast test_command].freeze
 
     def initialize(**kwargs)
       super
@@ -166,6 +166,7 @@ module Mutineer
       when "verbose"   then value == true || value.to_s == "true"
       when "ignore"    then Array(value).map(&:to_s)
       when "baseline"  then value.to_s
+      when "test_command" then value.to_s
       else value
       end
     end

--- a/lib/mutineer/external_backend.rb
+++ b/lib/mutineer/external_backend.rb
@@ -25,7 +25,8 @@ module Mutineer
     # Generous ceiling for the one-off smoke/calibration run (a cold app boot plus
     # the full suite). The per-mutant timeout is derived from how long this took.
     SMOKE_TIMEOUT = 900
-    # Poll interval for the wait loop (matches Isolation).
+    # Poll interval for the deadline wait loop. Independent of Isolation's loop —
+    # this backend waits on an external process TREE, not an in-process fork.
     POLL = 0.02
 
     # Turn a command template into an argv array (no shell → no eval, no
@@ -80,7 +81,11 @@ module Mutineer
       kind, code, output, elapsed = spawn_capture(command, files, timeout)
       return elapsed if kind == :exited && code&.zero?
 
-      reason = kind == :timeout ? "did not finish within #{timeout}s" : "exited #{code}"
+      reason =
+        if kind == :timeout then "did not finish within #{timeout}s"
+        elsif code.nil?      then "was terminated by a signal"
+        else                      "exited #{code}"
+        end
       detail = output.empty? ? "" : "\n--- last output ---\n#{tail(output)}"
       raise SmokeCheckError,
             "the test command #{reason} against the UNMUTATED source — the " \
@@ -97,11 +102,21 @@ module Mutineer
     # @api private
     def self.spawn_capture(command, files, timeout)
       argv = build_argv(command, files)
-      raise SmokeCheckError, "--test-command produced an empty command" if argv.empty?
+      # Unreachable in practice (validate_test_command! guarantees a non-empty
+      # command with %{files}); a neutral ArgumentError, not the smoke-specific
+      # SmokeCheckError, since this is not a smoke-check failure.
+      raise ArgumentError, "--test-command produced an empty command" if argv.empty?
 
       out = Tempfile.create("mutineer_ext")
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      pid = Process.spawn(*argv, out: out, err: %i[child out])
+      # `pgroup: true` puts the child in its OWN process group so a timeout can
+      # kill the whole tree (`bundle exec rails test` forks parallel workers;
+      # spring/bundler add more) — killing only the leader would orphan workers
+      # that keep holding the shared DB, corrupting later serial mutants. The
+      # explicit [program, argv0] form guarantees the no-shell exec path even for a
+      # degenerate single-element argv (Process.spawn(*argv) would route a lone
+      # metachar-bearing string through /bin/sh, breaking the argv-only invariant).
+      pid = Process.spawn([argv.first, argv.first], *argv[1..], out: out, err: %i[child out], pgroup: true)
       kind, code = wait_with_timeout(pid, timeout)
       elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
       out.rewind
@@ -121,7 +136,14 @@ module Mutineer
         return [:exited, status.exitstatus] if reaped
 
         if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-          Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
+          # Kill the whole process GROUP (negative pid) so forked test workers die
+          # with the leader; fall back to the leader alone if the group is already
+          # gone. The child led its group (pgroup: true at spawn).
+          begin
+            Process.kill(:KILL, -pid)
+          rescue Errno::ESRCH, Errno::EPERM
+            Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
+          end
           Process.waitpid(pid) rescue nil # rubocop:disable Style/RescueModifier
           return [:timeout, nil]
         end

--- a/lib/mutineer/external_backend.rb
+++ b/lib/mutineer/external_backend.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "tempfile"
+require_relative "result"
+
+module Mutineer
+  # Raised when the smoke check (the unmutated suite) is not green, so the run
+  # aborts before scoring — a broken environment must never be reported as strong
+  # tests. The CLI maps this to a runtime error (exit 1), not a usage error.
+  class SmokeCheckError < StandardError; end
+
+  # #27 (U3): the external execution backend. Runs the user's `--test-command` as a
+  # subprocess in the app's OWN runtime (whatever Ruby its bundle resolves to), so
+  # mutineer (Ruby >= 3.4) can mutation-test apps pinned to an older Ruby.
+  #
+  # This is deliberately NOT a `TestRunners` framework adapter: those return an
+  # Integer 0/1 from inside a fork and are dispatched by framework name. This is a
+  # whole backend — it spawns a process, enforces a wall-clock timeout, and maps
+  # the exit status to a Result. The mapping is the SAME direction as in-process
+  # (suite passes => survived, suite fails => killed) but coarser: it cannot tell an
+  # infrastructure error from a genuine kill, so the smoke check (below) guards the
+  # persistent case and the score is disclosed as an upper bound (KTD-3/KTD-6).
+  module ExternalBackend
+    # Generous ceiling for the one-off smoke/calibration run (a cold app boot plus
+    # the full suite). The per-mutant timeout is derived from how long this took.
+    SMOKE_TIMEOUT = 900
+    # Poll interval for the wait loop (matches Isolation).
+    POLL = 0.02
+
+    # Turn a command template into an argv array (no shell → no eval, no
+    # injection). The `%{files}` token expands IN PLACE to N separate argv
+    # elements — one per path, unescaped — so a path containing a space stays a
+    # single argument. It is not a space-joined string.
+    #
+    # @param command [String] the --test-command template (contains %{files}).
+    # @param files [Array<String>] test file paths to substitute.
+    # @return [Array<String>] argv.
+    def self.build_argv(command, files)
+      Shellwords.split(command).flat_map { |tok| tok == "%{files}" ? files : [tok] }
+    end
+
+    # Runs the command for ONE mutant against whatever is currently on disk (the
+    # caller has already swapped the mutant in via FileSwap). Maps the outcome to a
+    # Result. Env is inherited by the subprocess, so `RAILS_ENV=test mutineer …`
+    # reaches the child with no parsing here.
+    #
+    # @param command [String] the --test-command template.
+    # @param files [Array<String>] test file paths.
+    # @param timeout [Numeric] per-mutant wall-clock timeout in seconds.
+    # @param verbose [Boolean] print the child's captured output on a non-pass.
+    # @return [Mutineer::Result]
+    def self.run(command, files, timeout:, verbose: false)
+      kind, code, output, = spawn_capture(command, files, timeout)
+      case kind
+      when :timeout
+        # A timeout is the one non-pass we flag by default — a normal kill is also
+        # a non-zero exit, so notifying on every non-zero would spam every kill.
+        warn "[mutineer] test-command exceeded #{timeout}s and was killed (scored timeout)."
+        warn output if verbose && !output.empty?
+        Result.timeout
+      else # :exited
+        return Result.survived if code&.zero?
+
+        warn output if verbose && !output.empty?
+        Result.killed
+      end
+    end
+
+    # Pre-flight: run the command once against the UNMUTATED tree. Green (exit 0)
+    # returns the elapsed seconds (used to calibrate the per-mutant timeout);
+    # anything else raises SmokeCheckError so the run aborts before scoring.
+    #
+    # @param command [String] the --test-command template.
+    # @param files [Array<String>] test file paths.
+    # @param timeout [Numeric] ceiling for the calibration run.
+    # @return [Float] elapsed seconds of the clean run.
+    # @raise [Mutineer::SmokeCheckError] when the clean suite is not green.
+    def self.smoke_check!(command, files, timeout: SMOKE_TIMEOUT)
+      kind, code, output, elapsed = spawn_capture(command, files, timeout)
+      return elapsed if kind == :exited && code&.zero?
+
+      reason = kind == :timeout ? "did not finish within #{timeout}s" : "exited #{code}"
+      detail = output.empty? ? "" : "\n--- last output ---\n#{tail(output)}"
+      raise SmokeCheckError,
+            "the test command #{reason} against the UNMUTATED source — the " \
+            "environment looks broken (check DB, RAILS_ENV, migrations), not the " \
+            "tests weak.#{detail}"
+    end
+
+    # Spawns the command to a captured combined-output tempfile, enforces a
+    # wall-clock timeout (SIGKILL past the deadline), and returns
+    # [kind, exit_code, output, elapsed]. Mirrors Isolation's single-waiter loop:
+    # we are the only caller of waitpid on this pid, so the kill can never hit a
+    # reaped/recycled pid.
+    #
+    # @api private
+    def self.spawn_capture(command, files, timeout)
+      argv = build_argv(command, files)
+      raise SmokeCheckError, "--test-command produced an empty command" if argv.empty?
+
+      out = Tempfile.create("mutineer_ext")
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      pid = Process.spawn(*argv, out: out, err: %i[child out])
+      kind, code = wait_with_timeout(pid, timeout)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+      out.rewind
+      [kind, code, out.read, elapsed]
+    ensure
+      if out
+        out.close
+        File.unlink(out.path) rescue nil # rubocop:disable Style/RescueModifier
+      end
+    end
+
+    # @api private
+    def self.wait_with_timeout(pid, timeout)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        reaped, status = Process.waitpid2(pid, Process::WNOHANG)
+        return [:exited, status.exitstatus] if reaped
+
+        if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+          Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
+          Process.waitpid(pid) rescue nil # rubocop:disable Style/RescueModifier
+          return [:timeout, nil]
+        end
+        sleep POLL
+      end
+    end
+
+    # Last ~40 lines of captured output, for a smoke-failure message.
+    #
+    # @api private
+    def self.tail(output, lines = 40)
+      output.lines.last(lines).join
+    end
+  end
+end

--- a/lib/mutineer/external_backend.rb
+++ b/lib/mutineer/external_backend.rb
@@ -128,7 +128,14 @@ module Mutineer
       end
     end
 
+    # Waits for the spawned pid, SIGKILLing its process group past the deadline.
+    # Single-waiter deadline loop (mirrors Isolation), so the kill can never hit a
+    # reaped/recycled pid.
+    #
     # @api private
+    # @param pid [Integer] the spawned child pid.
+    # @param timeout [Numeric] wall-clock deadline in seconds.
+    # @return [Array(Symbol, Integer, nil)] `[:exited, code]` or `[:timeout, nil]`.
     def self.wait_with_timeout(pid, timeout)
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
       loop do

--- a/lib/mutineer/file_swap.rb
+++ b/lib/mutineer/file_swap.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module Mutineer
+  # Raised when a source file's backup already exists as FileSwap.with begins —
+  # a second mutineer run is racing on the same file (the backup path is shared
+  # and unlocked). Aborting beats silently leaving the tree mutated.
+  class ConcurrentRunError < StandardError
+    def initialize(backup)
+      super("a backup already exists at #{backup} — is another mutineer run active " \
+            "in this directory? Aborting to avoid corrupting the source file.")
+    end
+  end
+
   # #27 (U2): apply one whole-file mutant to the REAL source path for the external
   # (`--test-command`) backend, and guarantee the original is restored on every
   # exit path. A separate `bundle exec` subprocess has its own VM and cannot see an
@@ -28,14 +38,25 @@ module Mutineer
     # @yield the block to run while the mutant is on disk.
     # @return [Object] the block's return value.
     def self.with(source_file, mutated)
+      backup = source_file + BACKUP_SUFFIX
+      # A backup already on disk means either a prior hard-killed run (restore_orphans
+      # should have healed it at startup) or a SECOND mutineer run racing us on the
+      # same file. The backup path is shared and unlocked, so proceeding would let
+      # us capture the other run's mutant AS the "original" and permanently mutate
+      # the tree. Refuse loudly rather than silently corrupt — and do it BEFORE
+      # `created` is set, so the ensure below never touches a backup we don't own.
+      raise ConcurrentRunError, backup if File.exist?(backup)
+
       original = File.binread(source_file)
-      backup   = source_file + BACKUP_SUFFIX
       File.binwrite(backup, original)
+      created = true
       File.binwrite(source_file, mutated)
       yield
     ensure
-      File.binwrite(source_file, original) if original
-      File.unlink(backup) if backup && File.exist?(backup)
+      if created
+        File.binwrite(source_file, original)
+        File.unlink(backup) if File.exist?(backup)
+      end
     end
 
     # Startup/after-run self-heal: restore any source file left mutated by a prior
@@ -50,9 +71,20 @@ module Mutineer
       dirs.uniq.each do |dir|
         Dir.glob(File.join(dir, "*#{BACKUP_SUFFIX}")).each do |backup|
           source_file = backup.delete_suffix(BACKUP_SUFFIX)
-          File.binwrite(source_file, File.binread(backup))
-          File.unlink(backup)
-          healed += 1
+          backup_bytes = File.binread(backup)
+          if !File.exist?(source_file)
+            # A real user file that merely ends in our suffix, with no sibling to
+            # restore — leave it untouched (never create a file from it).
+            next
+          elsif File.binread(source_file) == backup_bytes
+            # Redundant backup (e.g. a crash between restore and unlink): nothing to
+            # heal, just clear the orphan so the next run doesn't see a false race.
+            File.unlink(backup)
+          else
+            File.binwrite(source_file, backup_bytes)
+            File.unlink(backup)
+            healed += 1
+          end
         end
       end
       return if healed.zero?

--- a/lib/mutineer/file_swap.rb
+++ b/lib/mutineer/file_swap.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Mutineer
+  # #27 (U2): apply one whole-file mutant to the REAL source path for the external
+  # (`--test-command`) backend, and guarantee the original is restored on every
+  # exit path. A separate `bundle exec` subprocess has its own VM and cannot see an
+  # in-process `load`, so the mutant must live on disk while its suite runs — which
+  # makes leaving the file mutated the one genuinely dangerous failure mode.
+  #
+  # Defense in depth, mirroring the tempfile-orphan discipline
+  # (`Runner.sweep_orphans`, `isolation.rb` tempfiles):
+  #   - the original bytes are held in memory AND written to a sibling backup;
+  #   - `ensure` restores from memory around every mutant;
+  #   - the backup survives a SIGKILL (which skips `ensure`), so `restore_orphans`
+  #     can self-heal a left-mutated tree on the next run's startup.
+  # Only one mutant is in flight per file at a time (the external path is serial),
+  # so backups never collide.
+  module FileSwap
+    # Suffix for the on-disk backup; fixed so `restore_orphans` finds it.
+    BACKUP_SUFFIX = ".mutineer-backup"
+
+    # Writes `mutated` to `source_file`, yields, then restores the original bytes
+    # on every exit path (normal return, exception, or `ensure`). Byte-exact:
+    # binary read/write preserves encoding, newlines, and trailing bytes.
+    #
+    # @param source_file [String] path to the real source file.
+    # @param mutated [String] mutated source text to write for the duration.
+    # @yield the block to run while the mutant is on disk.
+    # @return [Object] the block's return value.
+    def self.with(source_file, mutated)
+      original = File.binread(source_file)
+      backup   = source_file + BACKUP_SUFFIX
+      File.binwrite(backup, original)
+      File.binwrite(source_file, mutated)
+      yield
+    ensure
+      File.binwrite(source_file, original) if original
+      File.unlink(backup) if backup && File.exist?(backup)
+    end
+
+    # Startup/after-run self-heal: restore any source file left mutated by a prior
+    # interrupted run (a leftover `*.mutineer-backup`), then remove the backup.
+    # Prints one line to stderr when it actually heals something, so a developer
+    # knows their working tree was auto-restored (a file they did not touch).
+    #
+    # @param dirs [Array<String>] directories to sweep for orphaned backups.
+    # @return [void]
+    def self.restore_orphans(dirs)
+      healed = 0
+      dirs.uniq.each do |dir|
+        Dir.glob(File.join(dir, "*#{BACKUP_SUFFIX}")).each do |backup|
+          source_file = backup.delete_suffix(BACKUP_SUFFIX)
+          File.binwrite(source_file, File.binread(backup))
+          File.unlink(backup)
+          healed += 1
+        end
+      end
+      return if healed.zero?
+
+      warn "[mutineer] restored #{healed} source file(s) left mutated by a previous interrupted run."
+    end
+  end
+end

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -102,9 +102,8 @@ module Mutineer
       # resolves). A SIGKILL'd child skips the tempfile's ensure-unlink, orphaning
       # it. `ensure` is unreliable vs SIGKILL, so the PARENT sweeps each source dir
       # before and after the run — orphans are impossible after a normal run.
-      source_dirs = config.sources
-                          .map { |f| File.dirname(File.expand_path(f, config.project_root)) }.uniq
-      sweep_orphans(source_dirs)
+      dirs = source_dirs(config)
+      sweep_orphans(dirs)
 
       strategy = config.strategy
       results =
@@ -122,7 +121,7 @@ module Mutineer
           # filter_map drops nils for jobs --fail-fast left unscheduled.
           bare.each_with_index.filter_map { |r, i| r&.with(subject: jobs[i][0], mutation: jobs[i][1], id: jobs[i][2]) }
         ensure
-          sweep_orphans(source_dirs)
+          sweep_orphans(dirs)
         end
 
       [AggregateResult.new(results + ignored_results), source_map]
@@ -172,22 +171,25 @@ module Mutineer
     # @param operator_classes [Array<Class>] resolved operators.
     # @return [Array(Mutineer::AggregateResult, Hash<String,String>)] aggregate and source map.
     def self.execute_external(config, operator_classes)
+      abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
+      dirs      = source_dirs(config)
+
+      # Heal any file a prior hard-killed run left mutated BEFORE reading source —
+      # collect_jobs computes mutation offsets/ids from the on-disk bytes, so a
+      # still-mutated file would yield garbage offsets against the later-healed
+      # source. Heal first, then discover jobs from the clean tree.
+      FileSwap.restore_orphans(dirs)
+
       jobs, ignored_results, source_map = collect_jobs(config, operator_classes)
       jobs = filter_since(jobs, source_map, config) if config.since
 
-      abs_tests   = config.tests.map { |t| File.expand_path(t, config.project_root) }
-      source_dirs = config.sources
-                          .map { |f| File.dirname(File.expand_path(f, config.project_root)) }.uniq
-
-      # Heal any file a prior hard-killed run left mutated before touching disk.
-      FileSwap.restore_orphans(source_dirs)
-
       # Calibrate the per-mutant timeout from the clean run (a real suite far
       # outlasts the 10s in-process fork budget), and abort if it isn't green.
-      # ponytail: 3x the clean run, floor 30s — a heuristic, widen if flaky suites
-      # need it; a real slow suite self-calibrates via the smoke elapsed.
+      # ponytail: 3x the clean run, floor 30s, ceiling 300s — a heuristic. The
+      # floor covers a fast suite; the ceiling bounds a hung mutant (infinite loop)
+      # so a handful can't stall a serial run for ~45min on a slow suite.
       smoke_elapsed = ExternalBackend.smoke_check!(config.test_command, abs_tests)
-      timeout = [smoke_elapsed * 3, 30].max.ceil
+      timeout = [[smoke_elapsed * 3, 30].max, 300].min.ceil
 
       results = []
       begin
@@ -198,7 +200,7 @@ module Mutineer
           break if config.fail_fast && r.survived? # #21: stop at the first survivor
         end
       ensure
-        FileSwap.restore_orphans(source_dirs)
+        FileSwap.restore_orphans(dirs)
       end
 
       [AggregateResult.new(results + ignored_results), source_map]
@@ -296,6 +298,17 @@ module Mutineer
 
       ENV["RAILS_ENV"] = "test"
       warn "[mutineer] RAILS_ENV was unset; defaulting to 'test' for --rails."
+    end
+
+    # The unique absolute directories holding the sources — the sweep target for
+    # both orphan mechanisms (in-process mutant tempfiles and external backup
+    # files). Shared so the path-expansion rule can't drift between the two paths.
+    #
+    # @api private
+    # @param config [Mutineer::Config] run configuration.
+    # @return [Array<String>] unique absolute source directories.
+    def self.source_dirs(config)
+      config.sources.map { |f| File.dirname(File.expand_path(f, config.project_root)) }.uniq
     end
 
     # Removes stale mutant tempfiles from the given directories.

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -11,6 +11,8 @@ require_relative "changed_lines"
 require_relative "mutator_registry"
 require_relative "worker_pool"
 require_relative "mutant_id"
+require_relative "file_swap"
+require_relative "external_backend"
 require "set"
 
 module Mutineer
@@ -37,6 +39,11 @@ module Mutineer
     # @return [Array(Mutineer::AggregateResult, Hash<String, String>)] aggregate and source map.
     def self.execute(config)
       operator_classes = MutatorRegistry.resolve(config.operators || MutatorRegistry::DEFAULT_NAMES)
+
+      # #27: the external backend runs the suite as a subprocess in the app's own
+      # runtime — it does no in-process boot/require or coverage build, so branch
+      # before any of that. The in-process path below is untouched.
+      return execute_external(config, operator_classes) if config.test_command
 
       # Boot mode: require the boot file ONCE so the app env (e.g. Rails) is booted
       # in the parent and inherited by every fork. Do NOT manually require the
@@ -87,31 +94,7 @@ module Mutineer
       end
 
       # Collect every (subject, mutation) up front so the pool can fan them out.
-      # #10: a mutant the user marked known-equivalent (inline disable-line comment
-      # or .mutineer.yml ignore id) is classified :ignored here and NEVER forked —
-      # it is removed from the killed+survived denominator so a strong file reaches
-      # 100%. The stable id is computed per subject (occurrence needs the full list)
-      # and carried on every job so the parent can reattach it after the run.
-      source_map = {}
-      disabled_map = {}
-      ignore_set = config.ignore.to_set
-      jobs = []
-      ignored_results = []
-      Project.discover(config.sources, only: config.only).each do |subject|
-        source = (source_map[subject.file] ||= File.read(subject.file))
-        disabled = (disabled_map[subject.file] ||= suppress_map(source))
-        mutations = operator_classes.flat_map { |klass| klass.new.mutations_for(subject, source) }
-        ids = MutantId.for_subject(subject, source, mutations)
-        mutations.each_with_index do |mutation, i|
-          id = ids[i]
-          line = source.byteslice(0, mutation.start_offset).count("\n") + 1
-          if suppressed?(mutation.operator, line, id, disabled, ignore_set)
-            ignored_results << Result.ignored.with(subject: subject, mutation: mutation, id: id)
-          else
-            jobs << [subject, mutation, id]
-          end
-        end
-      end
+      jobs, ignored_results, source_map = collect_jobs(config, operator_classes)
 
       jobs = filter_since(jobs, source_map, config) if config.since
 
@@ -143,6 +126,99 @@ module Mutineer
         end
 
       [AggregateResult.new(results + ignored_results), source_map]
+    end
+
+    # Collect every (subject, mutation, id) up front so a backend can run them.
+    # #10: a mutant the user marked known-equivalent (inline disable-line comment
+    # or .mutineer.yml ignore id) is classified :ignored here and NEVER run — it is
+    # removed from the killed+survived denominator so a strong file reaches 100%.
+    # The stable id is computed per subject (occurrence needs the full list) and
+    # carried on every job so the parent can reattach it after the run. Shared by
+    # the in-process and external (#27) backends so job selection can never drift.
+    #
+    # @return [Array(Array, Array<Result>, Hash<String,String>)] jobs, ignored, source_map.
+    def self.collect_jobs(config, operator_classes)
+      source_map = {}
+      disabled_map = {}
+      ignore_set = config.ignore.to_set
+      jobs = []
+      ignored_results = []
+      Project.discover(config.sources, only: config.only).each do |subject|
+        source = (source_map[subject.file] ||= File.read(subject.file))
+        disabled = (disabled_map[subject.file] ||= suppress_map(source))
+        mutations = operator_classes.flat_map { |klass| klass.new.mutations_for(subject, source) }
+        ids = MutantId.for_subject(subject, source, mutations)
+        mutations.each_with_index do |mutation, i|
+          id = ids[i]
+          line = source.byteslice(0, mutation.start_offset).count("\n") + 1
+          if suppressed?(mutation.operator, line, id, disabled, ignore_set)
+            ignored_results << Result.ignored.with(subject: subject, mutation: mutation, id: id)
+          else
+            jobs << [subject, mutation, id]
+          end
+        end
+      end
+      [jobs, ignored_results, source_map]
+    end
+
+    # #27: external backend orchestration. Runs each mutant's whole-file mutation on
+    # disk (crash-safe swap) and executes the user's --test-command as a subprocess
+    # in the app's own runtime. Serial by construction (KTD-5: one shared DB, no
+    # per-worker isolation yet). No coverage narrowing — every mutant runs the full
+    # --test set (KTD-6); the score is therefore an upper bound and not comparable
+    # to an in-process run (the CLI discloses this).
+    #
+    # @param config [Mutineer::Config] run configuration (test_command set).
+    # @param operator_classes [Array<Class>] resolved operators.
+    # @return [Array(Mutineer::AggregateResult, Hash<String,String>)] aggregate and source map.
+    def self.execute_external(config, operator_classes)
+      jobs, ignored_results, source_map = collect_jobs(config, operator_classes)
+      jobs = filter_since(jobs, source_map, config) if config.since
+
+      abs_tests   = config.tests.map { |t| File.expand_path(t, config.project_root) }
+      source_dirs = config.sources
+                          .map { |f| File.dirname(File.expand_path(f, config.project_root)) }.uniq
+
+      # Heal any file a prior hard-killed run left mutated before touching disk.
+      FileSwap.restore_orphans(source_dirs)
+
+      # Calibrate the per-mutant timeout from the clean run (a real suite far
+      # outlasts the 10s in-process fork budget), and abort if it isn't green.
+      # ponytail: 3x the clean run, floor 30s — a heuristic, widen if flaky suites
+      # need it; a real slow suite self-calibrates via the smoke elapsed.
+      smoke_elapsed = ExternalBackend.smoke_check!(config.test_command, abs_tests)
+      timeout = [smoke_elapsed * 3, 30].max.ceil
+
+      results = []
+      begin
+        jobs.each do |subject, mutation, id|
+          r = run_external(subject, mutation, config.test_command, abs_tests,
+                           timeout: timeout, verbose: config.verbose)
+          results << r.with(subject: subject, mutation: mutation, id: id)
+          break if config.fail_fast && r.survived? # #21: stop at the first survivor
+        end
+      ensure
+        FileSwap.restore_orphans(source_dirs)
+      end
+
+      [AggregateResult.new(results + ignored_results), source_map]
+    end
+
+    # Runs one mutant through the external backend: apply the whole-file mutation on
+    # disk, run the command, restore. KTD-8: an invalid (non-reparsing) mutant would
+    # fail to load and score a false `killed`, so skip it tool-side (Prism, already
+    # cheap) and never write the file — preserving the `skipped` verdict the
+    # in-process path gives at runner.rb's pre-fork check.
+    #
+    # @return [Mutineer::Result] verdict for this mutant.
+    def self.run_external(subject, mutation, command, abs_tests, timeout:, verbose:)
+      source  = File.read(subject.file)
+      mutated = mutation.apply(source)
+      return Result.skipped if Parser.parse_string(mutated).errors.any?
+
+      FileSwap.with(subject.file, mutated) do
+        ExternalBackend.run(command, abs_tests, timeout: timeout, verbose: verbose)
+      end
     end
 
     # Scan a source once into { line_number => :all | Set[operator_syms] } from

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -69,6 +69,33 @@ class CliTest < Minitest::Test
     assert_includes err, "cannot write to"
   end
 
+  # #27: --test-command usage errors — all exit 2 (usage), never a backtrace.
+  def test_test_command_empty_exits_two
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--test-command", "   ")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "--test-command must not be empty"
+  end
+
+  def test_test_command_without_files_placeholder_exits_two
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--test-command", "bundle exec rails test")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "must contain %{files}"
+  end
+
+  def test_test_command_with_redefine_exits_two
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb",
+                              "--test-command", "rake test %{files}", "--strategy", "redefine")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "supports only --strategy reload"
+  end
+
+  def test_test_command_with_boot_exits_two
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb",
+                              "--test-command", "rake test %{files}", "--boot", "config/environment")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "cannot be combined with --boot/--rails"
+  end
+
   # R5: a missing source/test path is a clean usage error, not an ENOENT backtrace.
   def test_missing_source_path_exits_two
     _, err, status = mutineer("run", "no_such_source.rb", "--test", "no_such_test.rb")

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -107,6 +107,26 @@ class ConfigTest < Minitest::Test
     assert_equal [], Config.resolve({}, {}, Set.new).ignore
   end
 
+  # #27: test_command is accepted from the config file (snake_case key) and
+  # resolves onto the Config; an explicit CLI value wins over the file.
+  def test_from_file_accepts_test_command
+    with_config("test_command: bundle exec rails test %{files}\n") do |path|
+      out, err = capture_io { @hash = Config.from_file(path) }
+      assert_empty out
+      assert_empty err
+      assert_equal({ test_command: "bundle exec rails test %{files}" }, @hash)
+      assert_equal "bundle exec rails test %{files}", Config.resolve({}, @hash, Set.new).test_command
+    end
+  end
+
+  def test_cli_test_command_overrides_file
+    with_config("test_command: from_file %{files}\n") do |path|
+      capture_io { @hash = Config.from_file(path) }
+      cfg = Config.resolve({ test_command: "from_cli %{files}" }, @hash, Set.new(%i[test_command]))
+      assert_equal "from_cli %{files}", cfg.test_command
+    end
+  end
+
   # --- framework: explicit value, config file, and auto-detect ---
 
   def test_from_file_accepts_framework

--- a/test/external_backend_test.rb
+++ b/test/external_backend_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+require "mutineer/external_backend"
+
+# #27 (U3): the external backend spawns the user's test command in the app's own
+# runtime and maps its exit status to a verdict. Uses `ruby -e` as a stand-in for
+# a real suite so the tests are hermetic.
+class ExternalBackendTest < Minitest::Test
+  Backend = Mutineer::ExternalBackend
+  RUBY = RbConfig.ruby
+
+  # Real commands (`bundle exec rails test %{files}`) carry no embedded quotes, so
+  # a script file is the faithful stand-in for a suite whose body has spaces/quotes.
+  def with_script(body)
+    Dir.mktmpdir("mutineer-ext") do |dir|
+      path = File.join(dir, "suite.rb")
+      File.write(path, body)
+      yield path
+    end
+  end
+
+  # argv construction — %{files} expands to N separate tokens, no shell.
+  def test_build_argv_expands_files_to_separate_tokens
+    argv = Backend.build_argv("bundle exec rails test %{files}", ["test/a_test.rb", "test/b_test.rb"])
+    assert_equal ["bundle", "exec", "rails", "test", "test/a_test.rb", "test/b_test.rb"], argv
+  end
+
+  def test_build_argv_keeps_space_containing_path_intact
+    argv = Backend.build_argv("run %{files}", ["dir with space/a_test.rb"])
+    assert_equal ["run", "dir with space/a_test.rb"], argv
+  end
+
+  # verdict mapping
+  def test_exit_zero_is_survived
+    result = Backend.run("#{RUBY} -e exit(0) %{files}", ["x"], timeout: 30)
+    assert_predicate result, :survived?
+  end
+
+  def test_exit_one_is_killed
+    result = Backend.run("#{RUBY} -e exit(1) %{files}", ["x"], timeout: 30)
+    assert_predicate result, :killed?
+  end
+
+  def test_other_nonzero_is_killed
+    result = Backend.run("#{RUBY} -e exit(3) %{files}", ["x"], timeout: 30)
+    assert_predicate result, :killed?
+  end
+
+  def test_timeout_is_timeout_and_fast
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    _out, err = capture_io do
+      @result = Backend.run("#{RUBY} -e sleep(10) %{files}", ["x"], timeout: 1)
+    end
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+    assert_predicate @result, :timeout?
+    assert_operator elapsed, :<, 5, "should kill near the 1s deadline, not wait 10s"
+    assert_match(/exceeded 1s/, err)
+  end
+
+  # Env is inherited by the subprocess — no KEY=val parsing on our side.
+  def test_env_is_inherited
+    ENV["MUTINEER_ENV_PROBE"] = "1"
+    with_script(%(exit(ENV["MUTINEER_ENV_PROBE"] == "1" ? 0 : 1))) do |path|
+      assert_predicate Backend.run("#{RUBY} #{path} %{files}", ["x"], timeout: 30), :survived?
+    end
+  ensure
+    ENV.delete("MUTINEER_ENV_PROBE")
+  end
+
+  # --verbose surfaces the child's captured output; default run stays quiet on a kill.
+  def test_verbose_prints_output_on_kill_default_quiet
+    with_script(%(STDOUT.puts "boom-detail"\nexit 1\n)) do |path|
+      cmd = "#{RUBY} #{path} %{files}"
+      _out, err = capture_io { Backend.run(cmd, ["x"], timeout: 30, verbose: true) }
+      assert_match(/boom-detail/, err)
+
+      _out2, err2 = capture_io { Backend.run(cmd, ["x"], timeout: 30) }
+      refute_match(/boom-detail/, err2)
+    end
+  end
+
+  # smoke check — green returns elapsed, non-green raises with the output tail.
+  def test_smoke_check_green_returns_elapsed
+    elapsed = Backend.smoke_check!("#{RUBY} -e exit(0) %{files}", ["x"], timeout: 30)
+    assert_kind_of Float, elapsed
+  end
+
+  def test_smoke_check_non_green_raises_with_output
+    with_script(%(STDOUT.puts "db down"\nexit 1\n)) do |path|
+      err = assert_raises(Mutineer::SmokeCheckError) do
+        Backend.smoke_check!("#{RUBY} #{path} %{files}", ["x"], timeout: 30)
+      end
+      assert_match(/environment looks broken/, err.message)
+      assert_match(/db down/, err.message)
+    end
+  end
+end

--- a/test/file_swap_test.rb
+++ b/test/file_swap_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+require "mutineer/file_swap"
+
+# #27 (U2): on-disk mutant swap must restore the original on every exit path —
+# the working tree is never left mutated. Mirrors the tempfile-orphan discipline
+# (parent sweep + startup self-heal) so even a SIGKILL leaves nothing behind.
+class FileSwapTest < Minitest::Test
+  def with_file(content)
+    Dir.mktmpdir("mutineer-swap") do |dir|
+      path = File.join(dir, "source.rb")
+      File.binwrite(path, content)
+      yield dir, path
+    end
+  end
+
+  def test_mutated_during_block_original_after
+    with_file("original\n") do |_dir, path|
+      seen = nil
+      Mutineer::FileSwap.with(path, "mutated\n") { seen = File.binread(path) }
+      assert_equal "mutated\n", seen
+      assert_equal "original\n", File.binread(path)
+    end
+  end
+
+  def test_backup_removed_after_clean_run
+    with_file("original\n") do |dir, path|
+      Mutineer::FileSwap.with(path, "mutated\n") { :ok }
+      assert_empty Dir.glob(File.join(dir, "*#{Mutineer::FileSwap::BACKUP_SUFFIX}"))
+    end
+  end
+
+  def test_restores_on_raise_and_propagates
+    with_file("original\n") do |_dir, path|
+      assert_raises(RuntimeError) do
+        Mutineer::FileSwap.with(path, "mutated\n") { raise "boom" }
+      end
+      assert_equal "original\n", File.binread(path)
+    end
+  end
+
+  def test_returns_block_value
+    with_file("original\n") do |_dir, path|
+      assert_equal 42, Mutineer::FileSwap.with(path, "mutated\n") { 42 }
+    end
+  end
+
+  # Byte-exact: encoding, trailing newline, and CRLF must survive the round trip.
+  def test_byte_exact_restoration
+    original = "# frozé\r\nx = 1\n".b
+    with_file(original) do |_dir, path|
+      Mutineer::FileSwap.with(path, "y = 2\n") { :ok }
+      assert_equal original, File.binread(path)
+    end
+  end
+
+  # Simulated hard kill: a mutated file + leftover backup on disk. Startup sweep
+  # restores the original and removes the backup, with a one-line notice.
+  def test_restore_orphans_heals_a_left_mutated_file
+    with_file("mutated-leftover\n") do |dir, path|
+      File.binwrite(path + Mutineer::FileSwap::BACKUP_SUFFIX, "original\n")
+      out, err = capture_io { Mutineer::FileSwap.restore_orphans([dir]) }
+      assert_equal "original\n", File.binread(path)
+      assert_empty Dir.glob(File.join(dir, "*#{Mutineer::FileSwap::BACKUP_SUFFIX}"))
+      assert_empty out
+      assert_match(/restored 1/, err)
+    end
+  end
+
+  def test_restore_orphans_noop_when_none
+    with_file("original\n") do |dir, _path|
+      out, err = capture_io { Mutineer::FileSwap.restore_orphans([dir]) }
+      assert_empty out
+      assert_empty err
+    end
+  end
+end

--- a/test/file_swap_test.rb
+++ b/test/file_swap_test.rb
@@ -76,4 +76,44 @@ class FileSwapTest < Minitest::Test
       assert_empty err
     end
   end
+
+  # Concurrency guard: a backup already on disk means a second run is racing on the
+  # same file. Refuse — and do NOT touch the existing backup or the source.
+  def test_with_raises_when_backup_already_exists
+    with_file("original\n") do |_dir, path|
+      backup = path + Mutineer::FileSwap::BACKUP_SUFFIX
+      File.binwrite(backup, "someone-elses-original\n")
+      assert_raises(Mutineer::ConcurrentRunError) do
+        Mutineer::FileSwap.with(path, "mutated\n") { flunk "block must not run" }
+      end
+      # The other run's backup and our source are left untouched.
+      assert_equal "someone-elses-original\n", File.binread(backup)
+      assert_equal "original\n", File.binread(path)
+    end
+  end
+
+  # A real user file that merely ends in the suffix, with no sibling, is left alone
+  # (never used to create a file).
+  def test_restore_orphans_ignores_suffixed_file_with_no_sibling
+    Dir.mktmpdir("mutineer-swap") do |dir|
+      stray = File.join(dir, "notes#{Mutineer::FileSwap::BACKUP_SUFFIX}")
+      File.binwrite(stray, "user data\n")
+      _out, err = capture_io { Mutineer::FileSwap.restore_orphans([dir]) }
+      assert_path_exists stray
+      refute_path_exists File.join(dir, "notes")
+      assert_empty err
+    end
+  end
+
+  # A redundant backup identical to the source (crash between restore and unlink)
+  # is cleared without a false "healed" notice, so the next run sees no race.
+  def test_restore_orphans_clears_stale_identical_backup
+    with_file("original\n") do |dir, path|
+      File.binwrite(path + Mutineer::FileSwap::BACKUP_SUFFIX, "original\n")
+      _out, err = capture_io { Mutineer::FileSwap.restore_orphans([dir]) }
+      assert_empty Dir.glob(File.join(dir, "*#{Mutineer::FileSwap::BACKUP_SUFFIX}"))
+      assert_equal "original\n", File.binread(path)
+      assert_empty err
+    end
+  end
 end

--- a/test/runner_external_test.rb
+++ b/test/runner_external_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "open3"
+require "tmpdir"
+require "fileutils"
+
+# #27 (U4/U5): end-to-end for the external --test-command backend. Drives the real
+# bin against copied fixtures, using `ruby <test_file>` as the app's suite (the
+# fixture tests `require "minitest/autorun"`, so they exit 0 on pass / 1 on fail —
+# exactly the external contract). No real Rails app needed in CI.
+class RunnerExternalTest < Minitest::Test
+  ROOT     = File.expand_path("..", __dir__)
+  BIN      = File.join(ROOT, "bin", "mutineer")
+  FIXTURES = File.expand_path("fixtures", __dir__)
+  RUBY     = RbConfig.ruby
+
+  def mutineer(*args, chdir:)
+    Open3.capture3(RUBY, "-I#{File.join(ROOT, 'lib')}", BIN, *args, chdir: chdir)
+  end
+
+  def with_project(test_file)
+    Dir.mktmpdir("mutineer-ext-proj") do |proj|
+      %w[calculator.rb].each { |f| FileUtils.cp(File.join(FIXTURES, f), File.join(proj, f)) }
+      FileUtils.cp(File.join(FIXTURES, test_file), File.join(proj, test_file))
+      yield proj
+    end
+  end
+
+  # Strong suite kills all 6 arithmetic mutants -> 100%, exit 0. Confirms no
+  # in-process boot happened and the upper-bound disclosure is printed.
+  def test_strong_suite_scores_100
+    with_project("calculator_strong_test.rb") do |proj|
+      out, err, status = mutineer("run", "calculator.rb", "--test", "calculator_strong_test.rb",
+                                  "--test-command", "#{RUBY} %{files}", chdir: proj)
+      assert_equal 0, status.exitstatus, "stdout:#{out}\nstderr:#{err}"
+      assert_match(/100(\.0)?%/, out)
+      assert_match(/upper bound/, err)
+    end
+  end
+
+  # Weak suite: 2 of 6 arithmetic mutants survive -> 66.7%. Threshold defaults to
+  # 0 so exit stays 0; survivors are reported.
+  def test_weak_suite_reports_survivors
+    with_project("calculator_weak_test.rb") do |proj|
+      out, _err, status = mutineer("run", "calculator.rb", "--test", "calculator_weak_test.rb",
+                                   "--test-command", "#{RUBY} %{files}", chdir: proj)
+      assert_equal 0, status.exitstatus
+      assert_match(/66\.7%/, out)
+    end
+  end
+
+  # The working tree is intact after a run — no mutated bytes, no leftover backup.
+  def test_source_restored_after_run
+    with_project("calculator_strong_test.rb") do |proj|
+      original = File.binread(File.join(proj, "calculator.rb"))
+      mutineer("run", "calculator.rb", "--test", "calculator_strong_test.rb",
+               "--test-command", "#{RUBY} %{files}", chdir: proj)
+      assert_equal original, File.binread(File.join(proj, "calculator.rb"))
+      assert_empty Dir.glob(File.join(proj, "*.mutineer-backup"))
+    end
+  end
+
+  # A command that fails on the UNMUTATED tree is a broken environment: abort
+  # before scoring (exit 1), name the diagnosis, run zero mutants.
+  def test_smoke_failure_aborts
+    with_project("calculator_strong_test.rb") do |proj|
+      out, err, status = mutineer("run", "calculator.rb", "--test", "calculator_strong_test.rb",
+                                  "--test-command", "#{RUBY} -e exit(1) %{files}", chdir: proj)
+      assert_equal 1, status.exitstatus
+      assert_match(/environment looks broken/, err)
+      refute_match(/mutation score/i, out)
+    end
+  end
+
+  # KTD-5: --jobs > 1 is forced to 1 with a notice (no per-worker DB isolation yet).
+  def test_jobs_forced_to_one
+    with_project("calculator_strong_test.rb") do |proj|
+      _out, err, status = mutineer("run", "calculator.rb", "--test", "calculator_strong_test.rb",
+                                   "--jobs", "4", "--test-command", "#{RUBY} %{files}", chdir: proj)
+      assert_equal 0, status.exitstatus
+      assert_match(/forcing --jobs 1/, err)
+    end
+  end
+end


### PR DESCRIPTION
## What / Why / How

**What.** Today the tool can't run at all against a Rails app pinned to an older Ruby (3.1–3.3) — exactly the mature, high-stakes codebases where mutation testing pays off most. This PR unblocks them.

**Why it's blocked.** The `--rails` workflow boots the app *inside the tool's own Ruby process*, which forces the tool's Ruby and the app's Ruby to be the same. The tool needs Ruby ≥3.4 (its parser ships only with 3.4); an app that says `ruby "3.1.6"` can never satisfy both at once.

**How this fixes it.** A new `--test-command` mode keeps the tool on ≥3.4 but runs the app's tests in a **separate process under the app's own Ruby/bundle**. For each mutant it applies the change on disk (with crash-safe backup/restore), runs the user's test command, reads pass/fail, and puts the file back. It's slower than the in-process path (the app re-boots per mutant) but it works on any Ruby today.

Closes the Phase 1 scope of #27. Phase 2 (a persistent app-side daemon that restores one-boot speed and converges with #26's parallel workers) is gated behind a spike and not in this PR.

Glossary: *mutant* = one small deliberate code change; *killed* = the suite caught it; *survived* = a test gap.

---

## Usage

```sh
RAILS_ENV=test mutineer run app/models/order.rb \
  --test test/models/order_test.rb \
  --test-command "bundle exec rails test %{files}"
```

- `%{files}` is required and expands to the `--test` paths as separate arguments (a path with a space stays one argument — no shell involved).
- Environment is inherited by the subprocess (set it on the mutineer command, as above).
- Also settable as `test_command:` in `.mutineer.yml`.

## Tradeoffs (Phase 1, all disclosed at runtime + in the README)

- **Slower** — the app re-boots per mutant.
- **No coverage narrowing** — every mutant runs the full `--test` set, so the score is an **upper bound and not comparable to an in-process `--rails` score** (uncovered mutants count as survivors; an infra failure is scored as a kill). A **smoke check** aborts before scoring if the unmutated suite isn't green.
- **Reload strategy only** (`--strategy redefine` is rejected) and **serial** (`--jobs` forced to 1). Safe parallelism is tracked in #26.

## Implementation (units U1–U6)

- **U1** — `--test-command` flag + `.mutineer.yml` key + validation (empty / missing `%{files}` / redefine+boot conflicts → exit 2; `--jobs>1` forced to 1).
- **U2** — `FileSwap`: crash-safe on-disk mutation with in-memory + sibling-backup restore, parent sweep, and startup self-heal.
- **U3** — `ExternalBackend`: argv-array subprocess spawn (no shell/eval), wall-clock timeout, exit-status → verdict mapping, smoke check.
- **U4** — wired into `Runner` via `execute_external`; `collect_jobs` extracted and shared so the in-process path is byte-for-byte unchanged; KTD-8 tool-side reparse skips invalid mutants before touching disk.
- **U5** — smoke-check pre-flight + `SmokeCheckError` → exit 1 + non-comparable-score notice.
- **U6** — README section + CHANGELOG.

## Quality

- Plan validated with intent-engineering (`ie-validate-plan`) before implementation; blocking findings resolved.
- Multi-lens code review (correctness / security / reliability / adversarial / maintainability) run on the diff; all confirmed findings fixed in `fix(review)`:
  - process-group kill on timeout (no orphaned Rails test workers),
  - heal-before-collect ordering,
  - concurrent-run backup race → hard error,
  - timeout ceiling, no-shell exec form, orphan-sweep clobber guards.
- **382 tests, 0 failures.** Zero new runtime dependencies; no `eval`; Prism + stdlib only.

Plan: `docs/plans/issue-27-ruby-lt-3.4.md`. Related: #26 (parallel workers — converges at the Phase 2 spike), #12 (why jobs=1), #11 (one-boot), #19 (fork + AR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->