### PR TITLE
feat(daemon): U5 — per-worker SQLite DB isolation + after_fork routing (#26)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,11 @@ require "rake/testtask"
 
 # Rails-dependent daemon integration tests: they spawn a daemon under the fixture
 # app's OWN bundle, so they belong with the dogfood job, never the zero-dep suite.
-DAEMON_TESTS = %w[test/daemon_client_test.rb test/runner_daemon_test.rb].freeze
+DAEMON_TESTS = %w[
+  test/daemon_client_test.rb
+  test/runner_daemon_test.rb
+  test/daemon_worker_db_test.rb
+].freeze
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "lib" << "test"

--- a/lib/mutineer/daemon_client.rb
+++ b/lib/mutineer/daemon_client.rb
@@ -55,15 +55,17 @@ module Mutineer
     # @param payload [Hash] {"code" => mutated ruby, "source_file" => path}.
     # @param tests [Array<String>] covering test file paths.
     # @param timeout [Numeric] per-mutant wall-clock timeout (seconds).
+    # @param worker [Integer] worker slot; the daemon routes the fork to
+    #   `<db>-<worker>` (#26 isolation). Defaults to 0 (serial in U5).
     # @return [String] one of survived/killed/error/timeout.
-    def request(id:, payload:, tests:, timeout:)
+    def request(id:, payload:, tests:, timeout:, worker: 0)
       # A crash can surface on the WRITE (daemon died idle between requests →
       # Errno::EPIPE) as well as the read (EOF), so guard both: either way, respawn
       # for future mutants and score THIS one error (re-running a crash-causing
       # mutant could loop). Never let a dead pipe abort the whole run.
       reply =
         begin
-          send_line("id" => id, "payload" => payload, "tests" => tests, "timeout" => timeout)
+          send_line("id" => id, "worker" => worker, "payload" => payload, "tests" => tests, "timeout" => timeout)
           read_line
         rescue Errno::EPIPE, IOError
           nil

--- a/lib/mutineer/daemon_server.rb
+++ b/lib/mutineer/daemon_server.rb
@@ -20,17 +20,23 @@ module Mutineer
   #
   # Protocol (one JSON object per line, both directions):
   #   boot in  : {"cmd":"boot","project_root":"...","boot":"config/environment",
-  #               "load_paths":["test"],"framework":"minitest","rails":true}
+  #               "load_paths":["test"],"framework":"minitest","rails":true,"schema":"db/schema.rb"}
   #   ready out: {"ready":true,"ruby":"3.3.6"}   (or {"ready":false,"error":"..."} then exit)
-  #   run  in  : {"id":N,"payload":{"code":"<ruby>","source_file":"app/models/order.rb"},
+  #   run  in  : {"id":N,"worker":I,"payload":{"code":"<ruby>","source_file":"app/models/order.rb"},
   #               "tests":["test/models/order_test.rb"],"timeout":30}
   #   verdict  : {"id":N,"verdict":"survived"|"killed"|"error"|"timeout"}
   #   quit in  : {"cmd":"quit"}
   #
+  # Worker isolation (#26/U5): when the app is Rails, each fork is routed to its own
+  # database `<db>-<worker>` via {RailsWorkerDb} BEFORE any test loads, so concurrent
+  # workers can't clobber each other's transactional fixtures. `worker` defaults to 0
+  # (serial). SQLite this pass; Postgres provisioning is U10.
+  #
   # Verdict mapping (KTD-5, Phase-2a honest limit): child exit 0=survived (suite
-  # passed), 1=killed (suite failed), 2=error (child raised AROUND the test — load or
-  # boot failure); parent-detected timeout. Tagging an in-TEST DB error as `error`
-  # (vs killed) is a Phase-2b concern (needs the after_fork adapter's re-raise).
+  # passed), 1=killed (suite failed), 2=error (child raised AROUND the test — load,
+  # boot, or worker-DB routing failure); parent-detected timeout. Tagging an in-TEST DB
+  # error (one fired inside a test body, vs at routing time) as `error` rather than
+  # `killed` is a U6 concern — only observable under the concurrent gate.
   module DaemonServer
     # Poll interval (seconds) for the per-fork deadline wait loop.
     POLL = 0.02
@@ -87,6 +93,7 @@ module Mutineer
         # tempfile's non-constant name during autoload setup.
         sweep_temps
         require File.expand_path(cfg["boot"]) if cfg["boot"]
+        setup_worker_db(cfg) if cfg["rails"]
       rescue Exception => e # rubocop:disable Lint/RescueException
         # Boot failed (bad boot path, app error) — tell the client and exit so it can
         # surface a clean error rather than hang on the handshake.
@@ -95,9 +102,25 @@ module Mutineer
         exit!(1)
       end
 
+      # Load the per-worker DB adapter app-side (sibling gem file, by relative path so
+      # it bypasses the app bundle — like this daemon itself). No-op unless the app has
+      # ActiveRecord. Records the adapter + schema path so each fork can route to its
+      # own database (#26 isolation, U5). SQLite-only this pass; a non-SQLite config
+      # raises in the fork and reads as `error`, never a mis-routed verdict.
+      def setup_worker_db(cfg)
+        require_relative "rails_worker_db"
+        @worker_db = RailsWorkerDb.available? ? RailsWorkerDb : nil
+        schema = cfg["schema"] && File.expand_path(cfg["schema"])
+        @schema_path = schema if schema && File.exist?(schema)
+      rescue LoadError => e
+        @errio.puts("[daemon] worker-DB routing unavailable: #{e.message}")
+        @worker_db = nil
+      end
+
       # Fork a child to run one mutant in isolation; decode its exit into a verdict.
       def run_mutant(req)
         timeout = req.fetch("timeout", 30)
+        worker  = req.fetch("worker", 0)
         pid = fork do
           # New process group so a per-fork timeout can SIGKILL the whole subtree
           # (carries the Phase-1 pgroup discipline), and silence the child's stdout so
@@ -106,6 +129,10 @@ module Mutineer
           $stdout.reopen(File::NULL, "w")
           code =
             begin
+              # Route THIS fork at its own worker database before any test loads, so
+              # concurrent workers can't clobber each other's fixtures (#26). A routing
+              # failure raises here and is scored `error` below, never a false verdict.
+              @worker_db&.after_fork(worker, @schema_path)
               apply_payload(req["payload"])
               run_tests(Array(req["tests"]))
             rescue Exception => e # rubocop:disable Lint/RescueException

--- a/lib/mutineer/rails_worker_db.rb
+++ b/lib/mutineer/rails_worker_db.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Mutineer
+  # #26/#27 Phase 2b (U5) — per-worker database isolation for the daemon path.
+  #
+  # Loaded APP-SIDE by {DaemonServer} (a sibling gem file, pulled in by absolute path
+  # so it bypasses the app bundle — the same trick {DaemonClient} uses to run
+  # `daemon_server.rb` under a bundle that has no mutineer). It uses the app's OWN
+  # already-booted ActiveRecord and NEVER `require "active_record"` (R10/KTD-8): every
+  # method that touches AR first confirms {available?}, so the daemon core stays
+  # framework-agnostic and the gem keeps its zero-runtime-dependency promise.
+  #
+  # Isolation model (KTD-7): each parallel worker gets its OWN database so concurrent
+  # forks can't clobber each other's transactional fixtures (the measured #26
+  # corruption). {after_fork} runs inside a freshly-forked child and points that
+  # child's connection at the worker's database BEFORE any test loads; transactional
+  # fixtures then repopulate that isolated database per test.
+  #
+  # Scope: this pass ships the **SQLite** adapter (per-worker file, hermetic,
+  # spike-proven). Postgres per-worker provisioning (`CREATE DATABASE <db>-<worker>` —
+  # the measured corruption case) extends {worker_db_config}/{provision} at the marked
+  # seam in U10; until then a non-SQLite config raises a clear NotImplementedError
+  # rather than silently mis-routing.
+  #
+  # Honest limit (KTD-5): routing failures surface as `error` via {verify_connection!}.
+  # Re-raising an AR error that fires *inside a test body* past Minitest (so an in-test
+  # DB failure is `error`, not `killed`) is only observable under concurrent load and
+  # is deferred to U6 with the parallel gate — noted, not silently skipped.
+  module RailsWorkerDb
+    # True when the app has ActiveRecord loaded — the only condition under which any
+    # other method here may touch AR. Never triggers an autoload/require of AR itself.
+    #
+    # @return [Boolean]
+    def self.available?
+      defined?(ActiveRecord::Base) ? true : false
+    end
+
+    # Derive a per-worker database path from a base path by inserting `-<worker>`
+    # before the extension. Pure string transform (no AR) so it is unit-testable in
+    # the zero-dep suite. `storage/test.sqlite3`, worker 1 -> `storage/test-1.sqlite3`.
+    #
+    # @param database [String] the base database path.
+    # @param worker [Integer] the worker slot index (0..N-1).
+    # @return [String] the per-worker database path.
+    def self.worker_database_path(database, worker)
+      ext = File.extname(database)
+      "#{database.delete_suffix(ext)}-#{worker}#{ext}"
+    end
+
+    # Build the AR connection config for one worker by copying the app's current
+    # (default test) config and swapping in the per-worker database path. SQLite only
+    # this pass — a non-SQLite adapter raises so the SQLite-first scope fails loud
+    # instead of mis-routing (Postgres is U10).
+    #
+    # @param worker [Integer] the worker slot index.
+    # @return [Hash] a symbol-keyed AR configuration hash for the worker database.
+    # @raise [NotImplementedError] when the app's database is non-SQLite or in-memory.
+    def self.worker_db_config(worker)
+      hash    = ActiveRecord::Base.connection_db_config.configuration_hash
+      adapter = hash[:adapter].to_s
+      unless adapter.start_with?("sqlite")
+        raise NotImplementedError,
+              "worker-DB isolation currently supports SQLite only (got adapter #{adapter.inspect}); " \
+              "Postgres per-worker provisioning is U10 (#26/#35)."
+      end
+
+      database = hash[:database].to_s
+      if database.empty? || database == ":memory:"
+        raise NotImplementedError,
+              "worker-DB isolation needs a file-backed database (got #{database.inspect})."
+      end
+
+      hash.merge(database: worker_database_path(database, worker))
+    end
+
+    # Child-side (after fork): route this process's ActiveRecord at the worker's own
+    # database and confirm it is reachable, so a routing failure reads as `error`
+    # (via the daemon's child rescue) rather than a false verdict. Loads the schema
+    # into the worker database when a schema path is given (idempotent — schema.rb
+    # runs with `force: true`), covering a fresh worker file.
+    #
+    # @param worker [Integer] the worker slot index.
+    # @param schema_path [String, nil] absolute path to `db/schema.rb`, or nil to skip.
+    # @return [void]
+    def self.after_fork(worker, schema_path = nil)
+      return unless available?
+
+      ActiveRecord::Base.establish_connection(worker_db_config(worker))
+      load_schema(schema_path) if schema_path
+      verify_connection!
+    end
+
+    # Explicit, parent-side provisioning: create + schema-load every worker database
+    # up front, then restore the app's default connection. This is the EXPLICIT
+    # provisioning entry point (V2 — never silent auto-create mid-audit) and the seam
+    # U10 extends for Postgres (`CREATE DATABASE` per worker). For SQLite the files are
+    # created on connect and the schema load makes them ready; idempotent to re-run.
+    #
+    # @param worker_count [Integer] number of worker databases to provision.
+    # @param schema_path [String, nil] absolute path to `db/schema.rb`, or nil to skip.
+    # @return [void]
+    def self.provision(worker_count, schema_path)
+      return unless available?
+
+      original = ActiveRecord::Base.connection_db_config
+      (0...worker_count).each do |worker|
+        ActiveRecord::Base.establish_connection(worker_db_config(worker))
+        load_schema(schema_path) if schema_path
+      end
+    ensure
+      ActiveRecord::Base.establish_connection(original) if original
+    end
+
+    # Load a Rails `schema.rb` into the current connection with its output silenced,
+    # so a parent-side {provision} call can never spill schema chatter onto the daemon
+    # IPC pipe. (In a fork the child's stdout is already `File::NULL`; this guards the
+    # parent path too.)
+    #
+    # @param schema_path [String] absolute path to `db/schema.rb`.
+    # @return [void]
+    def self.load_schema(schema_path)
+      ActiveRecord::Migration.verbose = false if defined?(ActiveRecord::Migration)
+      original = $stdout
+      $stdout = File.open(File::NULL, "w")
+      load schema_path
+    ensure
+      $stdout.close unless $stdout.equal?(original)
+      $stdout = original
+    end
+
+    # Force a round-trip to the freshly-routed connection so a broken route fails HERE
+    # (→ `error`) instead of later masquerading as a test failure (→ false `killed`).
+    #
+    # @return [void]
+    def self.verify_connection!
+      ActiveRecord::Base.connection.execute("SELECT 1")
+    end
+  end
+end

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -288,8 +288,23 @@ module Mutineer
         load_paths: test_load_roots(abs_tests),
         source_dirs: source_dirs(config), # so the daemon can sweep orphan mutant temps
         framework: config.framework,
-        rails: config.rails
+        rails: config.rails,
+        # #26/U5: schema for per-worker DB isolation. Sent when present; the daemon
+        # skips worker-DB schema loading if the path is absent (e.g. structure.sql apps).
+        schema: daemon_schema_path(config)
       }
+    end
+
+    # Absolute path to the app's `db/schema.rb` if it exists, else nil. Used by the
+    # daemon to schema-load each fork's isolated worker database (#26/U5). Only
+    # `schema.rb` is supported this pass; `structure.sql` apps get nil and fall back to
+    # whatever the worker DB already holds (Postgres provisioning is U10).
+    #
+    # @param config [Mutineer::Config] the run config.
+    # @return [String, nil] absolute schema path or nil.
+    def self.daemon_schema_path(config)
+      path = File.expand_path("db/schema.rb", config.project_root)
+      File.exist?(path) ? path : nil
     end
 
     # Map a daemon verdict string to a Result. The daemon reports the four run-time

--- a/test/daemon_worker_db_test.rb
+++ b/test/daemon_worker_db_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "mutineer/daemon_client"
+
+# #26/U5 — per-worker DB routing, proven end-to-end against the bundled fixture app.
+# Drives the daemon directly (via DaemonClient) so it can exercise MORE THAN ONE
+# worker slot serially: for each of worker 0 and worker 1, the unmutated source
+# SURVIVES and an arithmetic mutant is KILLED. That proves after_fork(worker) connects
+# each isolated `storage/test-<worker>.sqlite3`, loads its schema, and lets the
+# transactional fixtures repopulate it — the serial-correctness half of #26 (the
+# concurrent `--jobs N == --jobs 1` gate is U6).
+class DaemonWorkerDbTest < Minitest::Test
+  APP   = File.expand_path("fixtures/rails_app", __dir__)
+  ORDER = File.join(APP, "app/models/order.rb")
+  TEST  = File.join(APP, "test/models/order_test.rb")
+
+  def boot_config
+    {
+      project_root: APP,
+      boot: File.join(APP, "config/environment"),
+      load_paths: [File.join(APP, "test")],
+      source_dirs: [File.join(APP, "app/models")],
+      framework: "minitest",
+      rails: true,
+      schema: File.join(APP, "db/schema.rb")
+    }
+  end
+
+  def with_client
+    client = Mutineer::DaemonClient.new(boot: boot_config, app_root: APP).start
+    yield client
+  ensure
+    client&.quit
+  end
+
+  def verdict(client, id:, code:, worker:)
+    client.request(id: id, worker: worker, timeout: 60,
+                   payload: { "code" => code, "source_file" => ORDER },
+                   tests: [TEST])
+  end
+
+  def test_verdicts_are_correct_across_distinct_worker_dbs
+    original = File.read(ORDER)
+    # `*` -> `+`: subtotal 2*1000 becomes 1002, so the strong suite's
+    # `assert_equal 2000` fails -> the mutant is killed. Deterministic.
+    mutant = original.sub("quantity * unit_price_cents", "quantity + unit_price_cents")
+    refute_equal original, mutant, "the substitution must actually change the source"
+
+    with_client do |client|
+      [0, 1].each do |w|
+        assert_equal "survived", verdict(client, id: 10 + w, code: original, worker: w),
+                     "unmutated source survives on worker #{w}'s DB"
+        assert_equal "killed", verdict(client, id: 20 + w, code: mutant, worker: w),
+                     "arithmetic mutant is killed on worker #{w}'s DB"
+      end
+    end
+  end
+end

--- a/test/rails_worker_db_test.rb
+++ b/test/rails_worker_db_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "mutineer/rails_worker_db"
+
+# #26/U5 — zero-dep unit coverage for the pure parts of the worker-DB adapter. The
+# path-munging is the one bit of non-trivial logic that could break silently, so it
+# gets a fast check here; the AR-backed routing is proven end-to-end in
+# test/daemon_worker_db_test.rb (daemon suite, under the fixture app bundle).
+class RailsWorkerDbTest < Minitest::Test
+  def test_worker_database_path_inserts_worker_before_extension
+    assert_equal "storage/test-0.sqlite3",
+                 Mutineer::RailsWorkerDb.worker_database_path("storage/test.sqlite3", 0)
+    assert_equal "storage/test-3.sqlite3",
+                 Mutineer::RailsWorkerDb.worker_database_path("storage/test.sqlite3", 3)
+  end
+
+  def test_worker_database_path_handles_a_bare_name
+    assert_equal "mydb-1", Mutineer::RailsWorkerDb.worker_database_path("mydb", 1)
+  end
+
+  # R10: the adapter must never touch AR unless the app loaded it. In the zero-dep
+  # suite AR is absent, so `available?` must be a strict `false` (not nil) — the guard
+  # every other method relies on.
+  def test_available_reflects_active_record_presence
+    expected = defined?(ActiveRecord::Base) ? true : false
+    assert_equal expected, Mutineer::RailsWorkerDb.available?
+  end
+end


### PR DESCRIPTION
## What / Why / How

**What.** Groundwork so that mutation-testing a Rails app across several workers at once stops corrupting results. Each worker now gets its own copy of the test database.

**Why it matters.** A real audit runs the test suite hundreds of times. Running those in parallel is the biggest speed win — but today parallel workers share one test database and clobber each other's seed data, so results come out wrong. The fix is to give each worker its own database; this PR builds that routing.

**How.** When the daemon forks a child to test one mutant, the child's database connection is pointed at *that worker's own* SQLite file before any test runs. A routing failure is reported as an error rather than a false pass. SQLite only in this PR; Postgres is a later follow-up.

Glossary: *daemon* = the helper that boots the app once and runs each mutant's tests; *worker* = one parallel slot; *mutant* = one small code change under test.

---

### Technical (U5 of the #26/#27 Phase 2 plan)

- New `lib/mutineer/rails_worker_db.rb` — app-side adapter using the app's OWN ActiveRecord (`defined?(ActiveRecord::Base)` probe, **never** `require "active_record"` — R10). SQLite only; non-SQLite raises (Postgres is U10). `after_fork(worker)` establishes → schema-loads → verifies the connection so a bad route reads as `error`, not a false verdict.
- `daemon_server` loads the adapter at boot (Rails only) and routes each fork to its worker slot; `worker` added to the run protocol (defaults 0, i.e. serial).
- `daemon_client`/`runner` thread the worker slot + schema path through.
- `Rakefile`: the new daemon integration test joins `DAEMON_TESTS` (kept out of the zero-dep suite).

**Scope:** serial correctness (worker 0). The concurrent `--jobs N == --jobs 1` gate is the next PR (U6). Postgres provisioning is deferred (U10).

**Gate:** fast 385/0 · daemon 6/0 · yard:strict 100%.

Part of #26 / #27 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-worker SQLite DB isolation to the daemon so parallel workers don’t overwrite each other’s test data. Each fork is routed to its own DB before tests run; routing failures return error instead of a false verdict.

- **New Features**
  - Route each fork to `<db>-<worker>` via `after_fork(worker)`, then load schema and verify the connection before tests.
  - New app-side `RailsWorkerDb` uses the app’s ActiveRecord; SQLite only (non-SQLite raises). Postgres comes later.
  - Protocol adds `worker` (defaults to 0). Runner now passes the `schema` path when `db/schema.rb` exists.
  - Tests: unit coverage for path logic and end-to-end daemon test across workers 0 and 1; added to `DAEMON_TESTS`.

<sup>Written for commit 6c60797a5683e1d265e34547ba6f2ca2e715d579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

