### PR TITLE
feat(cli): U8 — --daemon opt-in flag + usage guards (#26/#27)

### DIFF
--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -468,6 +468,15 @@ module Mutineer
              "and an infra failure is scored as a kill."
       end
 
+      # #26/U8: same disclosure as --test-command above — the daemon backend has no
+      # coverage narrowing yet (Phase 2c), so this score is a lower bound (uncovered
+      # mutants count as survivors) and not comparable to an in-process run.
+      if config.daemon
+        warn "[mutineer] --daemon score is a lower bound, not comparable to an " \
+             "in-process run: no coverage narrowing yet (uncovered mutants count as " \
+             "survivors)."
+      end
+
       # #14: nudge toward the opt-in tier-2 operators (human report only — never
       # pollute JSON output).
       if !%w[json html].include?(config.format) && (hint = tier2_hint(config.operators))

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -51,6 +51,9 @@ module Mutineer
                              subprocess (for apps on Ruby < 3.4). CMD must contain
                              %{files} (expands to the --test paths). Env is inherited,
                              e.g. RAILS_ENV=test mutineer run ... --test-command "..."
+        --daemon             Boot the app ONCE in a persistent daemon and fork per
+                             mutant, with per-worker DB isolation so --jobs N is safe
+                             under Rails (needs --rails/--boot; not with --test-command)
         --format human|json|html  Report format (default: human)
         --output FILE        Write the report to FILE instead of stdout
         --dry-run            List mutations without executing
@@ -112,6 +115,9 @@ module Mutineer
         # #27: run the target suite as a subprocess in the app's OWN runtime so
         # mutineer (Ruby >= 3.4) can mutation-test apps pinned to an older Ruby.
         o.on("--test-command CMD") { |v| opts[:test_command] = v; explicit << :test_command }
+        # #26/#27 Phase 2: boot the app ONCE in a persistent daemon and fork per
+        # mutant, with per-worker DB isolation so --jobs N is safe under Rails.
+        o.on("--daemon") { opts[:daemon] = true; explicit << :daemon }
       end
 
       begin
@@ -242,6 +248,7 @@ module Mutineer
       end
 
       validate_test_command!(config) if config.test_command
+      validate_daemon!(config, explicit) if config.daemon
 
       validate_since!(config) if config.since
       preflight_output!(config.output) if config.output
@@ -298,6 +305,30 @@ module Mutineer
 
       warn "[mutineer] --test-command runs serially (no per-worker DB isolation yet); forcing --jobs 1."
       config.jobs = 1
+    end
+
+    # #26/#27 Phase 2 (U8): --daemon selects the persistent-daemon backend (boot once,
+    # fork per mutant, per-worker DB isolation). Two usage errors, both exit 2 (KTD-10):
+    # it cannot be combined with --test-command (choose ONE backend — never silently
+    # pick one), and it requires an app to boot (--rails or --boot). Under Rails,
+    # Config.resolve already keeps --jobs serial unless the user explicitly asks for
+    # parallelism, and each worker gets its own SQLite database on demand — so there is
+    # no "missing worker DB" precondition to check here for SQLite. Postgres worker-DB
+    # provisioning + its missing-DB error (KTD-9) arrives with the Postgres adapter (U10).
+    #
+    # @api private
+    # @param config [Mutineer::Config] run configuration.
+    # @param explicit [Set<Symbol>] explicit CLI fields.
+    # @return [void]
+    def self.validate_daemon!(config, _explicit = Set.new)
+      if config.test_command
+        warn "mutineer: choose one backend — --daemon and --test-command cannot be combined"
+        exit 2
+      end
+      return if config.rails || config.boot
+
+      warn "mutineer: --daemon needs an app to boot; add --rails (or --boot FILE)"
+      exit 2
     end
 
     # --since needs a real git repo and a resolvable ref; either failure is a

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -25,9 +25,8 @@ module Mutineer
     :cache_dir, :project_root, :load_paths,
     :jobs, :format, :output, :strategy, :require_paths,
     :boot, :rails, :since, :framework, :verbose, :ignore,
-    # :daemon / :daemon_timeout are NOT user-facing yet — no CLI flag or KNOWN_KEYS
-    # entry until the Phase 2c `--daemon` unit lands (which adds the flag + a `to_i`
-    # coerce + KNOWN_KEYS). For now they're set programmatically (tests/Runner).
+    # :daemon is user-facing as of U8 (--daemon flag + KNOWN_KEYS + boolean coerce).
+    # :daemon_timeout stays programmatic (set by tests/Runner; no flag yet).
     :baseline, :baseline_epsilon, :fail_fast, :test_command,
     :daemon, :daemon_timeout,
     keyword_init: true
@@ -35,7 +34,7 @@ module Mutineer
     # Config file name.
     CONFIG_FILE = ".mutineer.yml"
     # Keys accepted in .mutineer.yml (R7). `require` maps to the :require_paths field.
-    KNOWN_KEYS = %w[operators jobs threshold only require boot rails since framework verbose ignore baseline fail_fast test_command].freeze
+    KNOWN_KEYS = %w[operators jobs threshold only require boot rails since framework verbose ignore baseline fail_fast test_command daemon].freeze
 
     def initialize(**kwargs)
       super
@@ -168,6 +167,7 @@ module Mutineer
       when "boot"      then value.to_s
       when "framework" then value.to_s
       when "rails"     then value == true || value.to_s == "true"
+      when "daemon"    then value == true || value.to_s == "true"
       when "verbose"   then value == true || value.to_s == "true"
       when "ignore"    then Array(value).map(&:to_s)
       when "baseline"  then value.to_s

--- a/test/cli_daemon_test.rb
+++ b/test/cli_daemon_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "open3"
+require "rbconfig"
+require "mutineer/config"
+
+# #26/#27 Phase 2 (U8): the --daemon opt-in flag + its usage guards. Drives the real
+# binary so flag parsing + validation exit codes are exercised end to end; the two
+# usage errors fire during validation, before any daemon boots, so this stays in the
+# zero-dep suite (no fixture app bundle needed).
+class CliDaemonTest < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+  BIN  = File.join(ROOT, "bin", "mutineer")
+
+  def mutineer(*args)
+    Open3.capture3(RbConfig.ruby, "-I#{File.join(ROOT, 'lib')}", BIN, *args, chdir: Dir.tmpdir)
+  end
+
+  # KTD-10: --daemon and --test-command are two backends; combining them is a usage
+  # error (exit 2), never a silent pick.
+  def test_daemon_with_test_command_is_a_usage_error
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon", "--test-command", "run %{files}")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "choose one backend"
+  end
+
+  # The daemon must boot an app; --daemon with neither --rails nor --boot is a usage
+  # error (exit 2).
+  def test_daemon_without_rails_or_boot_is_a_usage_error
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "needs an app to boot"
+  end
+
+  # --daemon --rails clears the daemon usage checks; the run still fails later (the
+  # fixture app isn't present in the tmp dir), but NOT with a daemon usage error —
+  # proving the guard accepts the valid combo rather than rejecting it.
+  def test_daemon_with_rails_passes_daemon_validation
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon", "--rails")
+    refute_includes err, "needs an app to boot"
+    refute_includes err, "choose one backend"
+    refute_equal 0, status.exitstatus
+  end
+
+  # --daemon is settable in .mutineer.yml (KNOWN_KEYS) with boolean coercion.
+  def test_daemon_is_a_known_config_key_with_boolean_coercion
+    assert_includes Mutineer::KNOWN_KEYS, "daemon"
+    assert_equal true,  Mutineer::Config.coerce("daemon", true, "f")
+    assert_equal true,  Mutineer::Config.coerce("daemon", "true", "f")
+    assert_equal false, Mutineer::Config.coerce("daemon", false, "f")
+  end
+end

--- a/test/runner_daemon_test.rb
+++ b/test/runner_daemon_test.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 require "mutineer/config"
 require "mutineer/runner"
+require "mutineer/cli"
 
 # #26/#27 Phase 2a (U4): Runner.execute_daemon drives the persistent daemon serially
 # against the bundled fixture app and produces the SAME verdicts the in-process
@@ -41,5 +42,15 @@ class RunnerDaemonTest < Minitest::Test
     refute_empty aggregate.surviving_mutants, "weak suite should leave survivors"
     assert_operator aggregate.mutation_score, :<, 100.0
     assert_operator aggregate.killed_count, :>, 0, "weak suite still kills some"
+  end
+
+  # #26/U8: the daemon backend has no coverage narrowing yet, so its score is not
+  # comparable to an in-process run — the CLI must disclose that on every --daemon
+  # run, symmetric to the --test-command "upper bound" disclosure (cli.rb:465).
+  def test_cli_discloses_lower_bound_on_daemon_run
+    _out, err = capture_io do
+      assert_raises(SystemExit) { Mutineer::CLI.execute(config_for("order_test.rb")) }
+    end
+    assert_match(/--daemon score is a lower bound/, err)
   end
 end


### PR DESCRIPTION
## What / Why / How

**What.** Give users a switch to turn the new daemon backend on, with guardrails so it can't be misused.

**Why it matters.** The daemon and its safe parallelism aren't useful until there's a documented way to opt into them — and a couple of invalid combinations need to fail with a clear message instead of doing something surprising.

**How.** A single `--daemon` flag selects the backend (also settable in `.mutineer.yml`). Two mistakes are caught up front with a clear error: combining `--daemon` with the other backend (`--test-command`), and asking for `--daemon` without telling Mutineer how to boot the app (`--rails`/`--boot`).

---

### Technical (U8 of the #26/#27 Phase 2 plan)

- `--daemon` boolean, following the shipped `--test-command`/`--baseline` pattern (flag + `KNOWN_KEYS` + boolean coerce; `.mutineer.yml` `daemon: true` works).
- `validate_daemon!` — two usage errors, both exit 2 (KTD-10): `--daemon` + `--test-command` → "choose one backend"; `--daemon` without `--rails`/`--boot` → "needs an app to boot".
- Help banner + the stale "not user-facing yet" config comment updated.

**Missing-worker-DB handling (KTD-9):** under `--rails`, `Config.resolve` already keeps `--jobs` serial unless explicitly asked, and each worker's SQLite DB is created on demand (U5) — so there is no missing-DB precondition for SQLite. Postgres provisioning + its missing-DB error land with the PG adapter (U10). No dead code shipped for it.

**Stacked on** #37 (U6) → #36 (U5). Merge those first.

**Gate:** fast 389/0 · daemon 8/0 · yard:strict 100%.

Part of #26 / #27 Phase 2c (#35). Coverage narrowing (U7) and dogfood CI (U9) still to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `--daemon` flag to opt into the persistent daemon backend for safe parallel runs. Also adds a stderr warning that `--daemon` scores are lower bounds until coverage narrowing ships.

- **New Features**
  - New `--daemon` CLI flag; configurable via `.mutineer.yml` (`daemon: true`) with boolean coercion.
  - Validation: cannot combine `--daemon` with `--test-command`; requires `--rails` or `--boot` (both exit 2 with clear messages).
  - Updated help text and tests for parsing and validation.

- **Bug Fixes**
  - Added stderr disclosure for `--daemon`: no coverage narrowing yet, so the score is a lower bound and not comparable to in-process runs; test added.

<sup>Written for commit 6c8b45c843f2f1ff861e8ba7ca16764ce6f0acd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

