### PR TITLE
feat(daemon): U7 — restore coverage narrowing on the daemon path (#26/#27)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ DAEMON_TESTS = %w[
   test/runner_daemon_test.rb
   test/daemon_worker_db_test.rb
   test/runner_daemon_parallel_test.rb
+  test/daemon_coverage_test.rb
 ].freeze
 
 Rake::TestTask.new(:test) do |t|

--- a/lib/mutineer/coverage_map.rb
+++ b/lib/mutineer/coverage_map.rb
@@ -21,7 +21,24 @@ module Mutineer
   class CoverageMap
     DEFAULT_CAPTURE_TIMEOUT = 120 # seconds, per coverage subprocess (R3)
 
-    attr_reader :project_root, :failed_test_files, :phase_a_ran
+    attr_reader :project_root, :failed_test_files, :phase_a_ran, :map
+
+    # Build a QUERY-ONLY map from data captured elsewhere (the daemon builds the map
+    # app-side and ships `map` + `failed_test_files` over IPC; the tool reconstructs it
+    # here for per-mutant selection). Skips the capture machinery entirely — only the
+    # three fields #tests_for / #method_uncapturable? read are set (U7).
+    #
+    # @param map [Hash] the "file:line" => [test_files] map.
+    # @param failed_test_files [Array<String>] test files whose capture failed.
+    # @param project_root [String] project root (for path relativization).
+    # @return [Mutineer::CoverageMap] a query-only map.
+    def self.from_data(map:, failed_test_files:, project_root:)
+      instance = allocate
+      instance.instance_variable_set(:@map, map || {})
+      instance.instance_variable_set(:@failed_test_files, failed_test_files || [])
+      instance.instance_variable_set(:@project_root, project_root)
+      instance
+    end
 
     def initialize(source_paths:, test_paths:, cache_dir: ".mutineer",
                    load_paths: ["lib"], project_root: Dir.pwd,
@@ -54,9 +71,9 @@ module Mutineer
     # the booted parent instead. Inverts into the same map #tests_for reads, and
     # reuses the digest cache (the digest mixes in the boot file so a boot cache
     # never collides with a standalone one).
-    def build_via_fork(rails: false)
+    def build_via_fork(after_fork: nil)
       warn_external_sources
-      cached_or { run_phase_a_via_fork(rails: rails) }
+      cached_or { run_phase_a_via_fork(after_fork: after_fork) }
     end
 
     # Phase B lookup: the test files that cover `file:line`, or [] when none do.
@@ -159,7 +176,7 @@ module Mutineer
     # per-source coverage counts. record() inverts them exactly as the subprocess
     # path does. ponytail: serial fork (one test at a time) — boot apps fork
     # cheaply via COW and per-test isolation matters more than throughput here.
-    def run_phase_a_via_fork(rails:)
+    def run_phase_a_via_fork(after_fork:)
       @phase_a_ran = true
       @map = {}
       @failed_test_files = []
@@ -169,7 +186,7 @@ module Mutineer
         # Tri-state payload (KTD-1): Hash = coverage, String = error diagnostic
         # from the child, nil = pipe gone / empty.
         # ponytail/#9: this String diagnostic is what #9 turns into an :uncapturable status.
-        case (coverage = fork_capture(absolute(test_path), abs_sources, rails))
+        case (coverage = fork_capture(absolute(test_path), abs_sources, after_fork))
         when Hash   then record(coverage, test_path)
         when String
           fail_test(test_path, @verbose ? "fork capture failed: #{coverage}" :
@@ -182,7 +199,7 @@ module Mutineer
     # Fork the booted parent, run one test under the inherited Coverage, and
     # return its per-source counts hash (or nil on failure). Reuses the same
     # fork + Marshal-over-pipe + hard-exit! discipline as WorkerPool/Isolation.
-    def fork_capture(abs_test, abs_sources, rails)
+    def fork_capture(abs_test, abs_sources, after_fork)
       rd, wr = IO.pipe
       # #19: Marshal output is binary — an un-binmoded pipe can raise
       # Encoding::UndefinedConversionError on write, which the child's rescue then
@@ -193,7 +210,10 @@ module Mutineer
         rd.close
         payload =
           begin
-            Runner.send(:reconnect_active_record) if rails
+            # Fork-safety hook: the in-process path reconnects AR; the daemon routes
+            # to its worker DB. Nil (non-Rails) = no-op. Injected so this file needs
+            # neither Runner (Prism) nor Rails.
+            after_fork&.call
             Coverage.result(clear: true, stop: false) # discard pre-test delta
             TestRunners.for(@framework).run([abs_test])
             # lines:true yields {file => {lines: [...]}}; reduce to the counts

--- a/lib/mutineer/daemon_client.rb
+++ b/lib/mutineer/daemon_client.rb
@@ -76,6 +76,19 @@ module Mutineer
       "error"
     end
 
+    # #26/U7: ask the daemon to build the coverage map app-side and return it.
+    # One-shot control message (no id). Returns `{"map"=>..., "failed_test_files"=>...}`
+    # (possibly with an `"error"`), or nil if the daemon vanished — the caller then
+    # falls back to running the full test set (no narrowing) rather than mis-scoring.
+    #
+    # @return [Hash, nil] the coverage payload, or nil on a dead pipe.
+    def coverage
+      send_line("cmd" => "coverage")
+      read_line
+    rescue Errno::EPIPE, IOError
+      nil
+    end
+
     # Graceful shutdown; leaves no orphaned daemon/child.
     #
     # @return [void]

--- a/lib/mutineer/daemon_server.rb
+++ b/lib/mutineer/daemon_server.rb
@@ -73,6 +73,14 @@ module Mutineer
           end
           break if req["cmd"] == "quit"
 
+          # #26/U7: build the coverage map app-side and ship it to the tool, which
+          # then selects covering tests per mutant. One-shot control message.
+          if req["cmd"] == "coverage"
+            output.puts(JSON.generate(build_coverage_map))
+            output.flush
+            next
+          end
+
           output.puts(JSON.generate(run_mutant(req)))
           output.flush
         end
@@ -83,11 +91,18 @@ module Mutineer
       # BOOT ONCE. chdir + require the app's boot file so the whole app is loaded and
       # inherited by every fork. Never requires mutineer.
       def boot!(cfg)
+        @cfg = cfg
         @framework = cfg.fetch("framework", "minitest")
         @source_dirs = Array(cfg["source_dirs"]).map { |d| File.expand_path(d) }
         Dir.chdir(cfg["project_root"]) if cfg["project_root"]
         ENV["RAILS_ENV"] ||= "test" if cfg["rails"]
         Array(cfg["load_paths"]).each { |d| $LOAD_PATH.unshift(File.expand_path(d)) }
+        # #26/U7: start Coverage BEFORE the app loads, so booted source lines are
+        # instrumented — the map build (build_via_fork) forks this booted parent.
+        if cfg["coverage"]
+          require "coverage"
+          Coverage.start(lines: true)
+        end
         # Clear any mutant tempfile a prior SIGKILLed timeout child orphaned in a
         # source dir BEFORE the app boots — Zeitwerk would otherwise choke on the
         # tempfile's non-constant name during autoload setup.
@@ -115,6 +130,35 @@ module Mutineer
       rescue LoadError => e
         @errio.puts("[daemon] worker-DB routing unavailable: #{e.message}")
         @worker_db = nil
+      end
+
+      # #26/U7: build the coverage map app-side (Coverage was started at boot) and
+      # return it as `{map, failed_test_files}` for the tool to select covering tests.
+      # Capture forks route to worker 0's DB (isolated, serial). On any failure return
+      # an empty map + an error string — the tool then falls back to the full test set
+      # rather than mis-scoring everything as no_coverage.
+      def build_coverage_map
+        require_relative "coverage_map"
+        root = @cfg["project_root"] || Dir.pwd
+        cmap = CoverageMap.new(
+          source_paths: Array(@cfg["sources"]), test_paths: Array(@cfg["tests"]),
+          load_paths: Array(@cfg["load_paths"]), project_root: root,
+          boot_path: @cfg["boot"], framework: @framework, cache_dir: File.join(root, ".mutineer")
+        ).build_via_fork(after_fork: coverage_after_fork)
+        { "map" => cmap.map, "failed_test_files" => cmap.failed_test_files }
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        @errio.puts("[daemon] coverage build failed: #{e.class}: #{e.message}")
+        { "map" => {}, "failed_test_files" => [], "error" => "#{e.class}: #{e.message}" }
+      end
+
+      # Fork-safety hook for coverage capture: route each capture fork to worker 0's
+      # isolated DB (captures run serially, so one worker is enough). Nil when the app
+      # has no worker-DB adapter (non-Rails) — capture then runs as before.
+      def coverage_after_fork
+        return nil unless @worker_db
+
+        schema = @schema_path
+        -> { @worker_db.after_fork(0, schema) }
       end
 
       # Fork a child to run one mutant in isolation; decode its exit into a verdict.

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -90,7 +90,7 @@ module Mutineer
           load_paths: config.load_paths, framework: config.framework,
           boot_path: File.expand_path(config.boot, config.project_root),
           verbose: config.verbose
-        ).build_via_fork(rails: config.rails)
+        ).build_via_fork(after_fork: (config.rails ? -> { reconnect_active_record } : nil))
       else
         coverage_map = CoverageMap.new(
           source_paths: config.sources, test_paths: config.tests,
@@ -243,6 +243,12 @@ module Mutineer
       jobs = filter_since(jobs, source_map, config) if config.since
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
 
+      # #26/U7: build the coverage map once (app-side, via a short-lived daemon) so
+      # each mutant runs ONLY its covering tests and a mutant on an uncovered line is
+      # no_coverage. nil when the build fails — the runners fall back to the full
+      # --test set (no narrowing) rather than mis-scoring everything as no_coverage.
+      coverage_map = daemon_coverage_map(config, abs_tests)
+
       # #26/U6: worker count = resolved --jobs, capped at the job count (no idle
       # daemons). >1 → N concurrent daemon handles, each on its OWN worker DB (V6:
       # N-handles, the spike-proven shape). 1 → the serial single-daemon path.
@@ -251,25 +257,59 @@ module Mutineer
 
       results =
         if worker_count > 1
-          run_daemon_parallel(jobs, worker_count, config, abs_tests, source_map)
+          run_daemon_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
         else
-          run_daemon_serial(jobs, config, abs_tests, source_map)
+          run_daemon_serial(jobs, config, abs_tests, coverage_map, source_map)
         end
 
       [AggregateResult.new(results + ignored_results), source_map]
+    end
+
+    # #26/U7: build the coverage map via a short-lived daemon (boots the app once,
+    # captures per-test coverage app-side, ships the map back). Returns a query-only
+    # CoverageMap, or nil when the build fails / returns empty — callers then run the
+    # full --test set (no narrowing) rather than mis-scoring. The dedicated daemon
+    # costs one extra boot; correctness over that boot (ponytail — the map is reused
+    # for every mutant).
+    #
+    # @param config [Mutineer::Config] the run config.
+    # @param abs_tests [Array<String>] absolute --test paths.
+    # @return [Mutineer::CoverageMap, nil]
+    #
+    # ponytail: the coverage-build IPC read is unbounded (no wall-clock) — a --test
+    # file that infinite-loops during capture wedges this call, mirroring the existing
+    # in-process build_via_fork limitation. A capture timeout is a follow-up. When the
+    # map comes back empty (all captures failed), this returns nil and the run falls
+    # back to the FULL --test set per mutant — so on a total capture failure the daemon
+    # score is an upper bound (more testing), diverging from the in-process no_coverage
+    # scoring for that degenerate case only; a normal (nonempty) map scores identically.
+    def self.daemon_coverage_map(config, abs_tests)
+      client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests, coverage: true),
+                                app_root: config.project_root).start
+      data = begin
+        client.coverage
+      ensure
+        client.quit
+      end
+      return nil unless data && !(data["map"] || {}).empty?
+
+      CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
+                            project_root: config.project_root)
+    rescue DaemonBootError
+      nil
     end
 
     # Serial daemon path: one daemon (worker 0), one mutant at a time. Honors
     # --fail-fast (#21: stop at the first survivor).
     #
     # @return [Array<Mutineer::Result>] results in input order.
-    def self.run_daemon_serial(jobs, config, abs_tests, source_map)
+    def self.run_daemon_serial(jobs, config, abs_tests, coverage_map, source_map)
       client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests),
                                 app_root: config.project_root).start
       results = []
       begin
         jobs.each_with_index do |job, i|
-          r = daemon_job_result(job, i, client, 0, config, abs_tests, source_map)
+          r = daemon_job_result(job, i, client, 0, config, coverage_map, abs_tests, source_map)
           results << r
           break if config.fail_fast && r.survived?
         end
@@ -288,7 +328,7 @@ module Mutineer
     # workers drain, unscheduled jobs are left out (like the serial early break).
     #
     # @return [Array<Mutineer::Result>] completed results in input order.
-    def self.run_daemon_parallel(jobs, worker_count, config, abs_tests, source_map)
+    def self.run_daemon_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
       results    = Array.new(jobs.size)
       queue      = Queue.new
       jobs.each_index { |i| queue << i }
@@ -308,7 +348,7 @@ module Mutineer
             rescue ThreadError
               break
             end
-            r = daemon_job_result(jobs[i], i, client, worker, config, abs_tests, source_map)
+            r = daemon_job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
             results[i] = r
             stop_mutex.synchronize { stop = true } if config.fail_fast && r.survived?
           end
@@ -328,23 +368,61 @@ module Mutineer
     # @param client [Mutineer::DaemonClient] the daemon handle to run on.
     # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
     # @return [Mutineer::Result] the decorated result.
-    def self.daemon_job_result(job, req_id, client, worker, config, abs_tests, source_map)
+    def self.daemon_job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
       subject, mutation, id = job
-      mutated = mutation.apply(source_map[subject.file])
+      source  = source_map[subject.file]
+      mutated = mutation.apply(source)
       # KTD-8 (carried): skip an invalid mutant tool-side — never ship a payload that
       # would fail to load and read as a false `killed`.
+      # #26/U7: narrow to covering tests (shared with the in-process path via
+      # coverage_selection, so scores match). :verdict = no_coverage/uncapturable, no
+      # fork. No map (build failed) → run the full --test set (fallback, not narrowed).
+      sel = coverage_map && coverage_selection(subject.file, mutation, subject, source, coverage_map)
       r =
         if Parser.parse_string(mutated).errors.any?
           Result.skipped
+        elsif sel && sel[0] == :verdict
+          sel[1]
         else
           verdict = client.request(
             id: req_id, worker: worker, timeout: config.daemon_timeout || DAEMON_TIMEOUT,
             payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
-            tests: abs_tests
+            tests: sel ? sel[1] : abs_tests
           )
           daemon_result(verdict)
         end
       r.with(subject: subject, mutation: mutation, id: id)
+    end
+
+    # Coverage-based test selection, shared by the in-process ({run}) and daemon
+    # paths so both narrow identically (score parity, U7/V5). Returns
+    # `[:run, abs_test_paths]` when some test covers the mutant's line, or
+    # `[:verdict, Result]` (no_coverage / uncapturable) when none do.
+    #
+    # #9/#25: an empty selection is `:uncapturable` (not `:no_coverage`) when the
+    # mutant's enclosing method body got coverage from no *successful* capture but a
+    # sibling test failed to capture — the coverage was lost, not absent. Both are
+    # excluded from the score denominator, so this distinction is reporting-only and
+    # never changes the daemon-vs-in-process score.
+    #
+    # @param source_file [String] the mutated source file path.
+    # @param mutation [Mutineer::Mutation] the mutation (for its line offset).
+    # @param subject [Mutineer::Subject, nil] the subject (for its method body range).
+    # @param source [String] the original source text.
+    # @param coverage_map [Mutineer::CoverageMap] the built/loaded coverage map.
+    # @return [Array(Symbol, Object)] `[:run, Array<String>]` or `[:verdict, Result]`.
+    def self.coverage_selection(source_file, mutation, subject, source, coverage_map)
+      line   = source.byteslice(0, mutation.start_offset).count("\n") + 1
+      chosen = coverage_map.tests_for(source_file, line)
+      if chosen.empty?
+        # Method BODY range, not the whole def: the def/end lines are "covered" at
+        # class-load even when the body never runs (body_loc is the statements' span).
+        loc   = subject&.body_loc
+        range = loc ? (loc.start_line..loc.end_line) : (line..line)
+        return [:verdict, coverage_map.method_uncapturable?(source_file, range) ? Result.uncapturable : Result.no_coverage]
+      end
+
+      [:run, chosen.map { |t| File.expand_path(t, coverage_map.project_root) }]
     end
 
     # Default per-mutant timeout on the daemon path. Generous because 2a runs the full
@@ -354,7 +432,7 @@ module Mutineer
     # The boot config the daemon needs to boot the app once: where to boot, the test
     # load roots (so `require "test_helper"` resolves in every fork), framework, and
     # whether this is Rails.
-    def self.daemon_boot_config(config, abs_tests)
+    def self.daemon_boot_config(config, abs_tests, coverage: false)
       {
         project_root: config.project_root,
         boot: File.expand_path(config.boot || "config/environment", config.project_root),
@@ -364,7 +442,14 @@ module Mutineer
         rails: config.rails,
         # #26/U5: schema for per-worker DB isolation. Sent when present; the daemon
         # skips worker-DB schema loading if the path is absent (e.g. structure.sql apps).
-        schema: daemon_schema_path(config)
+        schema: daemon_schema_path(config),
+        # #26/U7: coverage narrowing. Only the short-lived map-building daemon starts
+        # Coverage (before boot); worker daemons boot with it OFF (no wasted
+        # instrumentation/memory across every mutant fork). `sources`/`tests` are the
+        # map-build inputs.
+        coverage: coverage,
+        sources: config.sources.map { |s| File.expand_path(s, config.project_root) },
+        tests: abs_tests
       }
     end
 
@@ -514,24 +599,12 @@ module Mutineer
 
       # Coverage selection (both standalone and boot mode): a mutation on a line
       # no test exercises is :no_coverage (no fork); otherwise exactly the
-      # covering test files run in the child.
-      line   = source.byteslice(0, mutation.start_offset).count("\n") + 1
-      chosen = coverage_map.tests_for(source_file, line)
-      # #9/#25: distinguish a genuine coverage gap from a line whose would-be test
-      # errored during capture (coverage lost) — the latter is :uncapturable.
-      # #25: taint per-METHOD (the mutant's enclosing def range), not whole-file,
-      # so a covered method's uncovered line stays :no_coverage while a method
-      # reachable only by a failed capture is :uncapturable.
-      if chosen.empty?
-        # Use the method BODY range, not the whole def: the `def`/`end` lines are
-        # "covered" at class-load even when the body never runs, which would mask
-        # an uncovered method. body_loc is the body statements' span.
-        loc = subject&.body_loc
-        range = loc ? (loc.start_line..loc.end_line) : (line..line)
-        return coverage_map.method_uncapturable?(source_file, range) ? Result.uncapturable : Result.no_coverage
-      end
+      # covering test files run in the child. Shared with the daemon path so both
+      # narrow identically (score parity, U7/V5).
+      kind, payload = coverage_selection(source_file, mutation, subject, source, coverage_map)
+      return payload if kind == :verdict
 
-      abs_tests = chosen.map { |t| File.expand_path(t, coverage_map.project_root) }
+      abs_tests = payload
 
       Isolation.run(timeout: timeout) do
         # Forking inherits the parent's live DB connection; sharing one socket

--- a/test/coverage_map_test.rb
+++ b/test/coverage_map_test.rb
@@ -76,7 +76,7 @@ class CoverageMapTest < Minitest::Test
   def test_fork_capture_returns_string_diagnostic_for_raising_child
     Coverage.start(lines: true) unless Coverage.running?
     map = fork_map(raising_test, verbose: true)
-    payload = map.send(:fork_capture, raising_test, [CALC], false)
+    payload = map.send(:fork_capture, raising_test, [CALC], nil)
     assert_kind_of String, payload
     assert_match(/RuntimeError: boom from child/, payload)
   end
@@ -88,7 +88,7 @@ class CoverageMapTest < Minitest::Test
     killed = File.join(Dir.mktmpdir, "suicide_test.rb")
     File.write(killed, %(Process.kill("KILL", Process.pid)\n))
     map = fork_map(killed, verbose: true)
-    payload = map.send(:fork_capture, killed, [CALC], false)
+    payload = map.send(:fork_capture, killed, [CALC], nil)
     assert_kind_of String, payload, "child death must produce a diagnostic, not nil"
     assert_match(/no result/, payload)
     assert_match(/signal 9|SIGKILL/, payload)
@@ -109,7 +109,7 @@ class CoverageMapTest < Minitest::Test
     Coverage.start(lines: true) unless Coverage.running?
     rt = raising_test
     map = fork_map(rt, verbose: true)
-    _, err = capture_subprocess_io { map.build_via_fork(rails: false) }
+    _, err = capture_subprocess_io { map.build_via_fork(after_fork: nil) }
     assert_match(/boom from child/, err)
     assert_includes map.failed_test_files.map { |f| File.basename(f) }, "raising_test.rb"
   end
@@ -118,7 +118,7 @@ class CoverageMapTest < Minitest::Test
     Coverage.start(lines: true) unless Coverage.running?
     rt = raising_test
     map = fork_map(rt, verbose: false)
-    _, err = capture_subprocess_io { map.build_via_fork(rails: false) }
+    _, err = capture_subprocess_io { map.build_via_fork(after_fork: nil) }
     assert_match(/re-run with --verbose/, err)
     refute_match(/boom from child/, err)
     assert_includes map.failed_test_files.map { |f| File.basename(f) }, "raising_test.rb"

--- a/test/daemon_coverage_test.rb
+++ b/test/daemon_coverage_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "mutineer/config"
+require "mutineer/runner"
+require "mutineer/daemon_client"
+
+# #26/U7 — coverage narrowing restored on the daemon path. The daemon builds the
+# coverage map app-side (Coverage started before boot) and ships it to the tool, which
+# then runs each mutant against ONLY its covering tests and marks mutants on uncovered
+# lines no_coverage (the Phase 1 regression, fixed). Proven against the fixture app.
+class DaemonCoverageTest < Minitest::Test
+  APP = File.expand_path("fixtures/rails_app", __dir__)
+
+  def config_for(test_file)
+    Mutineer::Config.new(
+      sources: [File.join(APP, "app/models/order.rb")],
+      tests: [File.join(APP, "test/models/#{test_file}")],
+      project_root: APP, boot: "config/environment",
+      rails: true, daemon: true, strategy: "reload", framework: "minitest"
+    )
+  end
+
+  def boot_config(test_file)
+    {
+      project_root: APP, boot: File.join(APP, "config/environment"),
+      load_paths: [File.join(APP, "test")], source_dirs: [File.join(APP, "app/models")],
+      framework: "minitest", rails: true, schema: File.join(APP, "db/schema.rb"),
+      coverage: true,
+      sources: [File.join(APP, "app/models/order.rb")],
+      tests: [File.join(APP, "test/models/#{test_file}")]
+    }
+  end
+
+  # The daemon builds the map app-side and returns it over IPC (the U7 machinery).
+  def test_daemon_builds_and_ships_a_coverage_map
+    client = Mutineer::DaemonClient.new(boot: boot_config("order_test.rb"), app_root: APP).start
+    data = begin
+      client.coverage
+    ensure
+      client.quit
+    end
+    refute_nil data, "daemon returns a coverage payload"
+    refute_empty data["map"], "the map is non-empty"
+    assert data["map"].keys.any? { |k| k.start_with?("app/models/order.rb:") },
+           "the map covers order.rb lines"
+  end
+
+  # R8: a mutant on a line no provided test exercises is no_coverage (excluded from
+  # score), NOT run as a false survivor. The subtotal-only suite leaves total_cents
+  # and free_shipping? uncovered, so their mutants must be no_coverage.
+  def test_uncovered_lines_are_no_coverage_on_the_daemon_path
+    aggregate, = Mutineer::Runner.execute(config_for("order_subtotal_only_test.rb"))
+    assert_operator aggregate.no_coverage_count, :>, 0,
+                    "mutants on the uncovered methods come back no_coverage"
+    assert_operator aggregate.covered_count, :>, 0,
+                    "subtotal_cents mutants are still run (covered)"
+  end
+end

--- a/test/fixtures/rails_app/test/models/order_subtotal_only_test.rb
+++ b/test/fixtures/rails_app/test/models/order_subtotal_only_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# PARTIAL-coverage suite: exercises ONLY subtotal_cents, leaving total_cents and
+# free_shipping? uncovered. Used by the daemon coverage test to prove that mutants on
+# the uncovered methods come back no_coverage (excluded from score), not survived.
+class OrderSubtotalOnlyTest < ActiveSupport::TestCase
+  def test_subtotal_is_quantity_times_unit_price
+    assert_equal 2000, orders(:small).subtotal_cents
+  end
+end


### PR DESCRIPTION
## What / Why / How

**What.** Make the daemon backend only run the tests that actually matter for each change, instead of the whole suite every time.

**Why it matters.** A mutation audit changes one line at a time and re-runs tests for each. Running the *entire* suite for a change that only one test touches is wasted work — and it also can't tell "no test covers this line" (a real gap) apart from "tests ran and passed". This restores the smart narrowing the daemon lost, and makes its score directly comparable to the in-process path.

**How.** The daemon measures, once, which tests exercise which lines, and hands that map to the tool. For each mutant the tool then runs only the covering tests; a change on a line no test touches is reported as "no coverage" (and excluded from the score) rather than a false pass.

Glossary: *coverage map* = which test files touch which source lines; *no_coverage* = a change on a line no test exercises.

---

### Technical (U7 of the #26/#27 Phase 2 plan)

- Daemon starts `Coverage` before booting and, on `{cmd:"coverage"}`, builds the map app-side (`build_via_fork`) and ships `{map, failed_test_files}`; the tool rebuilds a query-only `CoverageMap.from_data`.
- **Score parity (V5) by construction:** extracted the selection into a shared `Runner.coverage_selection` used by BOTH the in-process (`Runner.run`) and daemon paths — they narrow identically (strategy held constant: reload).
- Injected an `after_fork` proc into `CoverageMap#build_via_fork`, replacing a hardcoded `Runner.reconnect` that would `NameError` app-side (the daemon loads no mutineer core — verified Prism-free). Capture forks route to the worker-0 DB.
- Falls back to the full `--test` set when the coverage build returns empty (never mis-scores everything as no_coverage).

**Reviewed** (adversarial pass): no P0/P1. Fixed the one worth taking — `Coverage` now starts only in the short-lived map-builder daemon, not every worker. Two P2 caveats documented in-code (empty-map fallback score divergence on total capture failure; unbounded coverage-build IPC read, mirroring the existing in-process limit).

**Deferred:** parallelizing coverage *capture* (currently serial, one worker) — an optimization, not correctness.

**Stacked on** #38 (U8) → #37 (U6) → #36 (U5). Merge those first.

**Gate:** fast 389/0 · daemon 10/0 · yard:strict 100%.

Part of #26 / #27 Phase 2c (#35). U9 (dogfood CI + docs) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores coverage-based test selection on the daemon path so each mutant runs only its covering tests, and uncovered lines are reported as no_coverage. This matches the in-process path and speeds up daemon runs.

- **New Features**
  - Added `cmd:"coverage"`: the daemon starts `Coverage` before boot, builds the map app-side, and returns `{"map","failed_test_files"}`; the tool rebuilds a query-only map via `CoverageMap.from_data`.
  - Shared selection via `Runner.coverage_selection` so daemon and in-process narrow identically; uncovered lines yield `no_coverage` (or `uncapturable` when capture failed).
  - Safe fallback: if the map build fails or is empty, run the full `--test` set instead of mis-scoring.
  - Fork-safety for capture: `build_via_fork(after_fork:)` and `fork_capture(..., after_fork)` hook DB reconnect/routing; coverage capture forks use worker 0’s DB; only the short-lived map-builder daemon enables `Coverage`. Added `test/daemon_coverage_test.rb` with a partial-coverage fixture.

<sup>Written for commit 78d89354276a9349068427abced806905114bb74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

