### PR TITLE
feat(daemon): U9 — Rails dogfood + docs for the daemon backend (#26/#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`--daemon` backend — fast, parallel-safe Rails mutation testing** (#26/#27
+  Phase 2). Boots the app **once** in a persistent daemon and forks per mutant
+  (restoring shared-boot speed), and gives **each parallel worker its own
+  database** so `--jobs N` is safe under Rails for the first time — parallel
+  verdicts are proven identical to serial (no fixture cross-talk). Coverage
+  narrowing is restored on this path (each mutant runs only its covering tests;
+  a mutant on an uncovered line is `no_coverage`), so the daemon score is
+  comparable to the in-process `--rails` score. Opt in with `--rails --daemon`
+  (also `daemon: true` in `.mutineer.yml`); `--daemon` can't be combined with
+  `--test-command`. **SQLite** today (hermetic, CI-proven); **Postgres**
+  per-worker provisioning is in progress (#34/#35). The gem core stays Prism +
+  stdlib, zero runtime dependencies — worker-DB routing uses the app's own
+  ActiveRecord.
+
 ## [0.10.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | `--verbose` | Surface the real error when a fork capture fails (alias `--debug`) |
 | `--strategy NAME` | Mutation application: `reload` whole-file (default) or `redefine` surgical (`7a`/`7b` accepted as deprecated aliases) |
 | `--test-command CMD` | Run the suite as a subprocess in the app's own runtime (for apps on Ruby < 3.4); `CMD` must contain `%{files}`. See [Apps on Ruby < 3.4](#apps-on-ruby--34) |
+| `--daemon` | Boot the app once in a persistent daemon and fork per mutant, with per-worker DB isolation so `--jobs N` is safe under Rails (needs `--rails`/`--boot`; not with `--test-command`). See [the daemon backend](#faster-parallel-safe-rails-the---daemon-backend) |
 | `--format human\|json\|html` | Report format (default: human; `html` is a self-contained file) |
 | `--output FILE` | Write the report to FILE instead of stdout |
 | `--dry-run` | List candidate mutations without executing (honors suppression) |
@@ -104,6 +105,33 @@ Add Mutineer to your Gemfile's test group:
 gem "mutineer", group: :test, require: false
 ```
 
+### Faster, parallel-safe Rails (the `--daemon` backend)
+
+`--rails` boots your app once but runs mutants **serially** — parallel `--jobs`
+under Rails is unsafe, because every worker shares one test database and clobbers
+the others' fixtures. `--daemon` fixes both: it boots the app once in a persistent
+helper and forks per mutant, and gives **each parallel worker its own database**,
+so `--jobs N` is safe and its verdicts are proven identical to a serial run.
+
+```sh
+RAILS_ENV=test bundle exec mutineer run \
+  app/models/order.rb --test test/models/order_test.rb \
+  --rails --daemon --jobs 4
+```
+
+- **One boot, forked per mutant** — restores the shared-boot speed.
+- **Coverage-guided** — each mutant runs only its covering tests (like `--rails`);
+  a mutant on an uncovered line is `no_coverage`, so the score stays comparable to
+  the in-process `--rails` score.
+- **Safe `--jobs N`** — each worker routes to its own copy of the test database, so
+  parallel verdicts equal serial (no fixture cross-talk).
+- **One backend at a time** — `--daemon` can't be combined with `--test-command`
+  (choose one), and it needs an app to boot (`--rails` or `--boot`).
+
+Status: **SQLite** today (hermetic, CI-proven). **Postgres** per-worker
+provisioning is in progress (#34/#35); until it lands, use `--daemon` with a
+SQLite test database, or drop `--jobs` to run serially on other adapters.
+
 ### Apps on Ruby < 3.4
 
 Mutineer's own process needs Ruby ≥ 3.4 (it parses with stdlib Prism), and the
@@ -136,7 +164,8 @@ Tradeoffs (Phase 1) — this path is correct but not free:
   is scored as a kill. Mutineer prints this caveat on every run and aborts up
   front (a "smoke check") if your unmutated suite isn't green.
 - **Reload strategy only** (`--strategy redefine` is rejected on this path) and
-  **serial** (`--jobs` is forced to 1 — safe parallelism is tracked in #26).
+  **serial** (`--jobs` is forced to 1). For apps on Ruby ≥ 3.4, `--daemon` gives
+  safe parallelism instead (see [the daemon backend](#faster-parallel-safe-rails-the---daemon-backend)).
 
 ## Suppressing equivalent mutants
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ DAEMON_TESTS = %w[
   test/daemon_worker_db_test.rb
   test/runner_daemon_parallel_test.rb
   test/daemon_coverage_test.rb
+  test/rails_dogfood_daemon_test.rb
 ].freeze
 
 Rake::TestTask.new(:test) do |t|

--- a/test/rails_dogfood_daemon_test.rb
+++ b/test/rails_dogfood_daemon_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "mutineer/config"
+require "mutineer/runner"
+
+# #26/U9 — end-to-end dogfood of the daemon backend on the bundled Rails fixture app
+# (SQLite). The holistic proof that ties the phase together: a parallel run's verdicts
+# equal a serial run's AND the run emits ZERO database-contention warnings — the exact
+# corruption signal (#12/#26: PG deadlocks / "could not disable referential integrity")
+# that made --jobs unsafe under Rails before per-worker DB isolation. Postgres is U10;
+# error/killed/timeout distinctness is covered by the daemon core tests.
+class RailsDogfoodDaemonTest < Minitest::Test
+  APP = File.expand_path("fixtures/rails_app", __dir__)
+
+  def config_for(jobs)
+    Mutineer::Config.new(
+      sources: [File.join(APP, "app/models/order.rb")],
+      tests: [File.join(APP, "test/models/order_test.rb")],
+      project_root: APP, boot: "config/environment",
+      rails: true, daemon: true, strategy: "reload", framework: "minitest", jobs: jobs
+    )
+  end
+
+  def test_parallel_dogfood_matches_serial_with_no_db_warnings
+    serial = parallel = nil
+    # Daemons are subprocesses; capture at the fd level so their drained stderr
+    # (where any AR deadlock / referential-integrity warning would surface) is seen.
+    out, err = capture_subprocess_io do
+      serial,   = Mutineer::Runner.execute(config_for(1))
+      parallel, = Mutineer::Runner.execute(config_for(2))
+    end
+
+    assert_equal 100.0, parallel.mutation_score, "strong suite scores 100 under --jobs 2"
+    assert_equal serial.mutation_score, parallel.mutation_score, "--jobs 2 == --jobs 1"
+    assert_equal serial.killed_count, parallel.killed_count
+
+    combined = out + err
+    refute_match(/deadlock/i, combined, "no DB deadlock warnings under --jobs 2")
+    refute_match(/referential integrity/i, combined, "no referential-integrity warnings")
+    refute_match(/database is locked/i, combined, "no SQLite lock contention under --jobs 2")
+  end
+end


### PR DESCRIPTION
## What / Why / How

**What.** Prove the whole daemon backend works end-to-end on a real Rails app, and document how to use it.

**Why it matters.** Each earlier piece was tested on its own; this is the holistic check that the pieces work *together* — parallel results match serial *and* the run is clean of the database-contention errors that made parallel unsafe in the first place. Plus users need docs to actually turn it on.

**How.** A dogfood test runs the fixture app's suite under `--jobs 2` and `--jobs 1` and asserts identical verdicts with **zero** database-warning output. README and CHANGELOG gain a section explaining the daemon backend, when to use it, and its current SQLite-only status.

---

### Technical (U9 of the #26/#27 Phase 2 plan)

- `test/rails_dogfood_daemon_test.rb` — end-to-end: `--jobs 2 == --jobs 1`, score 100, and **zero** deadlock / referential-integrity / SQLite-lock warnings (the #12/#26 corruption signal, explicitly asserted). Captured at the fd level so the daemons' drained stderr is seen.
- Runs in the **existing** CI "rails dogfood" job (`ci.yml` already runs `rake test:daemon`) via `DAEMON_TESTS` — no new workflow.
- **Docs:** README `--daemon` backend section (one-boot + safe `--jobs` + coverage-guided; SQLite now, Postgres in progress) + options-table row; CHANGELOG Unreleased entry.

error/killed/timeout distinctness is covered by the daemon core tests; Postgres provisioning is the deferred follow-up (U10).

**Stacked on** #39 (U7) → #38 (U8) → #37 (U6) → #36 (U5). Merge those first.

**Gate:** fast 389/0 · daemon 11/0 · yard:strict 100%.

Completes Phase 2c (#35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proves the `--daemon` backend end-to-end on a real Rails app and adds docs on how to enable it. Confirms `--jobs 2` matches serial with zero DB contention; updates README and CHANGELOG.

- **New Features**
  - Added `test/rails_dogfood_daemon_test.rb`: runs `--rails --daemon` at `--jobs 1` and `--jobs 2`, asserts identical scores and no deadlock/referential-integrity/SQLite lock warnings; captures subprocess stderr; wired into CI via `DAEMON_TESTS`.
  - Docs: README adds a `--daemon` section and options row (one boot, per-worker DBs, coverage-guided, usage example); notes SQLite support now and that `--daemon` can’t be combined with `--test-command`. CHANGELOG adds Unreleased entry.
  - Aligns with Phase 2 (#26/#27) parallel-safe requirement; Postgres per-worker provisioning remains a follow-up (#34/#35).

<sup>Written for commit 3ce6de310011fe6db32893dffb32644fdfa6b9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

