### PR TITLE
feat(daemon): U10 part 1 — adapter-general worker-DB config shape, Postgres-ready (#34/#35)

### DIFF
--- a/lib/mutineer/rails_worker_db.rb
+++ b/lib/mutineer/rails_worker_db.rb
@@ -58,16 +58,38 @@ module Mutineer
     def self.worker_db_config(worker)
       hash    = ActiveRecord::Base.connection_db_config.configuration_hash
       adapter = hash[:adapter].to_s
+      # U10 seam: the config-SHAPING below (per_worker_config) is already
+      # adapter-general — it derives correct SQLite *and* Postgres worker-DB names.
+      # What's gated is runtime PROVISIONING: SQLite files are created on connect,
+      # but Postgres needs an explicit `CREATE DATABASE` per worker (U10). Until that
+      # lands, refuse non-SQLite loudly rather than route to a database that doesn't
+      # exist. To finish U10: implement provision() for PG and drop this guard.
       unless adapter.start_with?("sqlite")
         raise NotImplementedError,
-              "worker-DB isolation currently supports SQLite only (got adapter #{adapter.inspect}); " \
-              "Postgres per-worker provisioning is U10 (#26/#35)."
+              "worker-DB isolation currently provisions SQLite only (got adapter #{adapter.inspect}); " \
+              "Postgres per-worker provisioning is U10 (#26/#35) — use a SQLite test DB, or drop --jobs."
       end
 
+      per_worker_config(hash, worker)
+    end
+
+    # Pure config-shaping (no AR): given a connection config hash, return the
+    # per-worker variant with its database swapped to the worker's own name.
+    # Adapter-general — SQLite (`storage/test.sqlite3` → `storage/test-<w>.sqlite3`)
+    # and Postgres (`myapp_test` → `myapp_test-<w>`, Rails `parallelize` naming) both
+    # fall out of {worker_database_path}. Extracted + unit-tested so the Postgres
+    # SHAPE is proven ready for U10 without a live database.
+    #
+    # @param config_hash [Hash] a connection config hash (symbol or string keys).
+    # @param worker [Integer] the worker slot index.
+    # @return [Hash] the per-worker config (symbol keys), database swapped.
+    # @raise [NotImplementedError] for an in-memory or empty database (no per-worker split).
+    def self.per_worker_config(config_hash, worker)
+      hash     = config_hash.transform_keys(&:to_sym)
       database = hash[:database].to_s
       if database.empty? || database == ":memory:"
         raise NotImplementedError,
-              "worker-DB isolation needs a file-backed database (got #{database.inspect})."
+              "worker-DB isolation needs a file/name-backed database (got #{database.inspect})."
       end
 
       hash.merge(database: worker_database_path(database, worker))

--- a/test/rails_worker_db_test.rb
+++ b/test/rails_worker_db_test.rb
@@ -26,4 +26,25 @@ class RailsWorkerDbTest < Minitest::Test
     expected = defined?(ActiveRecord::Base) ? true : false
     assert_equal expected, Mutineer::RailsWorkerDb.available?
   end
+
+  # U10 seam: per_worker_config is adapter-general and pure (no AR), so the Postgres
+  # worker-DB naming is proven ready here — the remaining U10 work is PG provisioning
+  # (CREATE DATABASE), not the config shape.
+  def test_per_worker_config_derives_sqlite_worker_database
+    cfg = Mutineer::RailsWorkerDb.per_worker_config({ adapter: "sqlite3", database: "storage/test.sqlite3" }, 1)
+    assert_equal "storage/test-1.sqlite3", cfg[:database]
+    assert_equal "sqlite3", cfg[:adapter]
+  end
+
+  def test_per_worker_config_derives_postgres_worker_database
+    cfg = Mutineer::RailsWorkerDb.per_worker_config({ "adapter" => "postgresql", "database" => "myapp_test" }, 2)
+    assert_equal "myapp_test-2", cfg[:database], "Rails parallelize naming, PG-ready for U10"
+    assert_equal "postgresql", cfg[:adapter]
+  end
+
+  def test_per_worker_config_rejects_memory_database
+    assert_raises(NotImplementedError) do
+      Mutineer::RailsWorkerDb.per_worker_config({ adapter: "sqlite3", database: ":memory:" }, 0)
+    end
+  end
 end


### PR DESCRIPTION
## What / Why / How

**What.** A first, self-contained step toward Postgres support: teach the worker-database logic how to name a per-worker Postgres database, and prove it with tests — without needing a live Postgres yet.

**Why it matters.** Full Postgres support needs a running database server (to actually create the per-worker databases) that isn't available in this environment. Rather than write that database code blind and unverified, this lands the part that *can* be verified now — the naming/config logic — so the remaining Postgres work is a clean, well-scoped drop-in later.

**How.** The per-worker config-shaping is factored into a small pure function covering both SQLite and Postgres naming, with unit tests. The actual "create the database" step stays SQLite-only for now (it refuses Postgres with a clear message pointing at the follow-up), so nothing can route to a database that doesn't exist.

---

### Technical (U10 part 1 — Option C: adapter shape + unit tests, integration deferred)

- Extract `RailsWorkerDb.per_worker_config` — pure, adapter-general (no ActiveRecord): derives the per-worker database for **SQLite** (`storage/test.sqlite3` → `-<w>.sqlite3`) and **Postgres** (`myapp_test` → `myapp_test-<w>`, Rails `parallelize` naming). Unit-tested with plain hashes, so the PG shape is proven ready with no live DB.
- Runtime provisioning **stays SQLite-only**: the `worker_db_config` guard is kept (message now points at U10 + a remediation) so the runtime never routes to an unprovisioned Postgres database.

**Deferred (needs a Postgres environment — tracked in `docs/plans/INDEX-daemon.md` U10):** `CREATE DATABASE` provisioning, dropping the guard, the missing-DB error (exit 1), a PG fixture + CI `postgres:16` service + PG dogfood, and gating the KTD-5 re-raise under real PG concurrency. These finish U10 and let `--daemon` default.

**Stacked on** #40 (U9) → … → #36 (U5).

**Gate:** fast 392/0 · daemon 11/0 · yard:strict 100%.

Part of #34 / #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares U10 Postgres support by extracting an adapter-agnostic function to derive per-worker DB names, with tests to prove the PG naming shape. Runtime provisioning remains SQLite-only to avoid routing to non-existent PG databases. Part of #34/#35.

- New Features
  - Added `RailsWorkerDb.per_worker_config`: pure, adapter-general config shaping for per-worker DB names (SQLite: `storage/test-<w>.sqlite3`, Postgres: `myapp_test-<w>` using Rails parallelize naming).
  - Kept guard in `worker_db_config`: refuse non-SQLite with a clear message and remediation.
  - Added unit tests for SQLite naming, Postgres naming, and rejecting `:memory:` databases.

<sup>Written for commit 91e338495ab782fa9e22c1790650f1932ae66ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

