### PR TITLE
feat(daemon): U6 — concurrent daemon workers + --jobs N == --jobs 1 gate (#26)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ DAEMON_TESTS = %w[
   test/daemon_client_test.rb
   test/runner_daemon_test.rb
   test/daemon_worker_db_test.rb
+  test/runner_daemon_parallel_test.rb
 ].freeze
 
 Rake::TestTask.new(:test) do |t|

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -241,37 +241,110 @@ module Mutineer
     def self.execute_daemon(config, operator_classes)
       jobs, ignored_results, source_map = collect_jobs(config, operator_classes)
       jobs = filter_since(jobs, source_map, config) if config.since
-
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
+
+      # #26/U6: worker count = resolved --jobs, capped at the job count (no idle
+      # daemons). >1 → N concurrent daemon handles, each on its OWN worker DB (V6:
+      # N-handles, the spike-proven shape). 1 → the serial single-daemon path.
+      worker_count = [config.jobs || 1, 1].max
+      worker_count = [worker_count, jobs.size].min if jobs.size.positive?
+
+      results =
+        if worker_count > 1
+          run_daemon_parallel(jobs, worker_count, config, abs_tests, source_map)
+        else
+          run_daemon_serial(jobs, config, abs_tests, source_map)
+        end
+
+      [AggregateResult.new(results + ignored_results), source_map]
+    end
+
+    # Serial daemon path: one daemon (worker 0), one mutant at a time. Honors
+    # --fail-fast (#21: stop at the first survivor).
+    #
+    # @return [Array<Mutineer::Result>] results in input order.
+    def self.run_daemon_serial(jobs, config, abs_tests, source_map)
       client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests),
                                 app_root: config.project_root).start
-
       results = []
       begin
-        jobs.each_with_index do |(subject, mutation, id), i|
-          source  = source_map[subject.file]
-          mutated = mutation.apply(source)
-          # KTD-8 (carried): skip an invalid mutant tool-side — never ship a payload
-          # that would fail to load and read as a false `killed`.
-          r =
-            if Parser.parse_string(mutated).errors.any?
-              Result.skipped
-            else
-              verdict = client.request(
-                id: i, timeout: config.daemon_timeout || DAEMON_TIMEOUT,
-                payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
-                tests: abs_tests
-              )
-              daemon_result(verdict)
-            end
-          results << r.with(subject: subject, mutation: mutation, id: id)
-          break if config.fail_fast && r.survived? # #21: stop at the first survivor
+        jobs.each_with_index do |job, i|
+          r = daemon_job_result(job, i, client, 0, config, abs_tests, source_map)
+          results << r
+          break if config.fail_fast && r.survived?
         end
       ensure
         client.quit
       end
+      results
+    end
 
-      [AggregateResult.new(results + ignored_results), source_map]
+    # Parallel daemon path (#26/U6): N daemon handles, each pinned to its own worker
+    # slot (→ its own DB, so concurrent workers can't clobber each other's fixtures).
+    # A shared queue of job indices feeds N tool-side threads; each thread blocks on
+    # IPC (GVL released), so the N daemons run genuinely concurrently. Results are
+    # placed by input index and compacted, so the verdict SET is identical to serial
+    # regardless of finish order (R7). --fail-fast flips a shared stop flag; in-flight
+    # workers drain, unscheduled jobs are left out (like the serial early break).
+    #
+    # @return [Array<Mutineer::Result>] completed results in input order.
+    def self.run_daemon_parallel(jobs, worker_count, config, abs_tests, source_map)
+      results    = Array.new(jobs.size)
+      queue      = Queue.new
+      jobs.each_index { |i| queue << i }
+      stop       = false
+      stop_mutex = Mutex.new
+
+      clients = Array.new(worker_count) do
+        DaemonClient.new(boot: daemon_boot_config(config, abs_tests),
+                         app_root: config.project_root).start
+      end
+
+      clients.each_with_index.map do |client, worker|
+        Thread.new do
+          until stop_mutex.synchronize { stop }
+            i = begin
+              queue.pop(true) # non-blocking; ThreadError when drained
+            rescue ThreadError
+              break
+            end
+            r = daemon_job_result(jobs[i], i, client, worker, config, abs_tests, source_map)
+            results[i] = r
+            stop_mutex.synchronize { stop = true } if config.fail_fast && r.survived?
+          end
+        ensure
+          client.quit
+        end
+      end.each(&:join)
+
+      results.compact
+    end
+
+    # Build the payload for one job, run it on the given daemon/worker, and attach
+    # the subject/mutation/id — the shared body of both daemon paths.
+    #
+    # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
+    # @param req_id [Integer] request id (echoed back for IPC ordering safety).
+    # @param client [Mutineer::DaemonClient] the daemon handle to run on.
+    # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
+    # @return [Mutineer::Result] the decorated result.
+    def self.daemon_job_result(job, req_id, client, worker, config, abs_tests, source_map)
+      subject, mutation, id = job
+      mutated = mutation.apply(source_map[subject.file])
+      # KTD-8 (carried): skip an invalid mutant tool-side — never ship a payload that
+      # would fail to load and read as a false `killed`.
+      r =
+        if Parser.parse_string(mutated).errors.any?
+          Result.skipped
+        else
+          verdict = client.request(
+            id: req_id, worker: worker, timeout: config.daemon_timeout || DAEMON_TIMEOUT,
+            payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
+            tests: abs_tests
+          )
+          daemon_result(verdict)
+        end
+      r.with(subject: subject, mutation: mutation, id: id)
     end
 
     # Default per-mutant timeout on the daemon path. Generous because 2a runs the full

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -246,7 +246,12 @@ module Mutineer
       # #26/U6: worker count = resolved --jobs, capped at the job count (no idle
       # daemons). >1 → N concurrent daemon handles, each on its OWN worker DB (V6:
       # N-handles, the spike-proven shape). 1 → the serial single-daemon path.
+      # --fail-fast forces serial: parallel's stop flag fires on the first survivor
+      # by WALL-CLOCK, not input index, so the verdict set would diverge from serial
+      # (a different, non-deterministic survivor set/score) — the "identical to
+      # --jobs 1" guarantee below only holds when fail-fast can't race.
       worker_count = [config.jobs || 1, 1].max
+      worker_count = 1 if config.fail_fast
       worker_count = [worker_count, jobs.size].min if jobs.size.positive?
 
       results =
@@ -284,8 +289,11 @@ module Mutineer
     # A shared queue of job indices feeds N tool-side threads; each thread blocks on
     # IPC (GVL released), so the N daemons run genuinely concurrently. Results are
     # placed by input index and compacted, so the verdict SET is identical to serial
-    # regardless of finish order (R7). --fail-fast flips a shared stop flag; in-flight
-    # workers drain, unscheduled jobs are left out (like the serial early break).
+    # regardless of finish order (R7). `execute_daemon` never calls this with
+    # `config.fail_fast` set (forced to the serial path instead) — a wall-clock stop
+    # here, unlike serial's input-index break, would make the survivor set and score
+    # non-deterministic. The stop-flag machinery below stays as a defensive no-op for
+    # any direct caller that bypasses that guard.
     #
     # @return [Array<Mutineer::Result>] completed results in input order.
     def self.run_daemon_parallel(jobs, worker_count, config, abs_tests, source_map)

--- a/test/runner_daemon_parallel_test.rb
+++ b/test/runner_daemon_parallel_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "mutineer/config"
+require "mutineer/runner"
+
+# #26/U6 — the R7 correctness gate (non-negotiable, KTD-9). N concurrent daemon
+# workers, each pinned to its OWN isolated database, must produce verdicts IDENTICAL
+# to serial: same score, same kill count, same survivor set — with no transactional-
+# fixture cross-talk. Proven on SQLite here (Postgres is U10). This identity is what
+# lets `--jobs N` become safe (and, later, default) under Rails.
+class RunnerDaemonParallelTest < Minitest::Test
+  APP = File.expand_path("fixtures/rails_app", __dir__)
+
+  def config_for(test_file, jobs)
+    Mutineer::Config.new(
+      sources: [File.join(APP, "app/models/order.rb")],
+      tests: [File.join(APP, "test/models/#{test_file}")],
+      project_root: APP, boot: "config/environment",
+      rails: true, daemon: true, strategy: "reload",
+      framework: "minitest", jobs: jobs
+    )
+  end
+
+  # Order-independent outcome identity: parallel finish order must not change it.
+  def identity(aggregate)
+    {
+      score: aggregate.mutation_score,
+      killed: aggregate.killed_count,
+      survivors: aggregate.surviving_mutants.map(&:id).sort
+    }
+  end
+
+  def assert_parallel_matches_serial(test_file)
+    serial,   = Mutineer::Runner.execute(config_for(test_file, 1))
+    parallel, = Mutineer::Runner.execute(config_for(test_file, 2))
+    assert_equal identity(serial), identity(parallel),
+                 "--jobs 2 must equal --jobs 1 (score/kills/survivors) on #{test_file}"
+    [serial, parallel]
+  end
+
+  def test_strong_suite_jobs2_equals_jobs1_and_scores_100
+    serial, parallel = assert_parallel_matches_serial("order_test.rb")
+    assert_equal 100.0, parallel.mutation_score
+    assert_empty parallel.surviving_mutants, "strong suite leaves no survivors under --jobs 2"
+    assert_operator serial.killed_count, :>, 0
+  end
+
+  def test_weak_suite_jobs2_equals_jobs1_with_real_survivors
+    serial, parallel = assert_parallel_matches_serial("order_weak_test.rb")
+    refute_empty parallel.surviving_mutants, "weak suite should still leave survivors under --jobs 2"
+    assert_operator parallel.mutation_score, :<, 100.0
+    assert_operator serial.killed_count, :>, 0
+  end
+end

--- a/test/runner_daemon_parallel_test.rb
+++ b/test/runner_daemon_parallel_test.rb
@@ -12,13 +12,13 @@ require "mutineer/runner"
 class RunnerDaemonParallelTest < Minitest::Test
   APP = File.expand_path("fixtures/rails_app", __dir__)
 
-  def config_for(test_file, jobs)
+  def config_for(test_file, jobs, fail_fast: false)
     Mutineer::Config.new(
       sources: [File.join(APP, "app/models/order.rb")],
       tests: [File.join(APP, "test/models/#{test_file}")],
       project_root: APP, boot: "config/environment",
       rails: true, daemon: true, strategy: "reload",
-      framework: "minitest", jobs: jobs
+      framework: "minitest", jobs: jobs, fail_fast: fail_fast
     )
   end
 
@@ -51,5 +51,15 @@ class RunnerDaemonParallelTest < Minitest::Test
     refute_empty parallel.surviving_mutants, "weak suite should still leave survivors under --jobs 2"
     assert_operator parallel.mutation_score, :<, 100.0
     assert_operator serial.killed_count, :>, 0
+  end
+
+  # The identity above only holds because --fail-fast forces the serial path even
+  # under --jobs 2 (a wall-clock stop in the parallel path would make the survivor
+  # set/score non-deterministic). Proves the guard, not just its absence of crashing.
+  def test_fail_fast_jobs2_equals_fail_fast_jobs1
+    serial,   = Mutineer::Runner.execute(config_for("order_weak_test.rb", 1, fail_fast: true))
+    parallel, = Mutineer::Runner.execute(config_for("order_weak_test.rb", 2, fail_fast: true))
+    assert_equal identity(serial), identity(parallel),
+                 "--fail-fast --jobs 2 must equal --fail-fast --jobs 1 (guarded to serial)"
   end
 end


### PR DESCRIPTION
Reopens #37 (auto-closed when its base branch #36 was merged + deleted). Same U6 branch, now based on `main` (U5 already merged), plus a review fix (`--fail-fast` forces the serial path).

## What / Why / How

**What.** Turn on safe parallelism: run N mutants at once, each against its own database, and prove the parallel result is identical to running them one at a time.

**Why it matters.** Parallelism is the main speed lever for a mutation audit — but only if it's correct. This adds concurrency on top of the per-worker databases from #36, plus the non-negotiable check that `--jobs N` gives the same verdicts as `--jobs 1` (no fixture cross-talk, no corrupted scores).

**How.** The tool starts N daemon workers, each pinned to its own database, and hands them mutants from a shared queue. Each worker waits on its daemon over a pipe, so the N daemons genuinely run at once. Results are reassembled in original order, so finish-order can't change the outcome.

---

### Technical (U6 of the #26/#27 Phase 2 plan)

- `runner.execute_daemon` splits serial vs parallel. N daemon handles, each pinned to its worker slot → its own DB. Shared job queue → N tool-side threads (IPC blocks with GVL released → real concurrency). Order preserved via indexed results + compact. `--fail-fast` forces the serial path (review fix — avoids a partial-parallel race on the stop flag).
- Extracted `daemon_job_result` (shared serial/parallel payload builder).

**R7 gate (KTD-9):** `runner_daemon_parallel_test` asserts `--jobs 2 == --jobs 1` — same score, kill count, survivor-id set — on strong (100%) and weak (survivors) suites, SQLite. Postgres half is U10.

Completes Phase 2b (#34). Part of #26 / #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables safe parallelism in the daemon runner: run N mutants concurrently with per‑worker isolated databases and ensure results match `--jobs 1`. Adds tests that enforce `--jobs N == --jobs 1` and routes `--fail-fast` to the serial path.

- **New Features**
  - `execute_daemon` selects serial or parallel based on `--jobs` (capped to job count); each worker uses its own DB.
  - New `run_daemon_parallel`: N daemon handles + shared job queue; results are reassembled in input order.
  - Extracted `daemon_job_result` shared by serial and parallel paths.
  - New test `runner_daemon_parallel_test.rb` (wired in `Rakefile`) asserts identical score, kills, and survivor set for `--jobs 2` vs `--jobs 1` on strong and weak suites.

- **Bug Fixes**
  - Force serial under `--fail-fast` to avoid nondeterministic survivor sets from wall‑clock stop in parallel.

<sup>Written for commit 40f2fa2b4c02bc5908e5f16b455860315d7e7ad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

