### PR TITLE
release: v0.11.0 — --daemon backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,8 @@ Rails hardening + CI batch (issues #8–#13), all verified Rails-free.
 - `.mutineer.yml` configuration (CLI > config > default precedence).
 - Byte-correct source handling for multibyte (UTF-8) sources.
 
+[0.11.0]: https://github.com/davidteren/mutineer/releases/tag/v0.11.0
+[0.10.0]: https://github.com/davidteren/mutineer/releases/tag/v0.10.0
 [0.9.1]: https://github.com/davidteren/mutineer/releases/tag/v0.9.1
 [0.9.0]: https://github.com/davidteren/mutineer/releases/tag/v0.9.0
 [0.8.0]: https://github.com/davidteren/mutineer/releases/tag/v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-02
+
 ### Added
 - **`--daemon` backend — fast, parallel-safe Rails mutation testing** (#26/#27
   Phase 2). Boots the app **once** in a persistent daemon and forks per mutant

--- a/lib/mutineer/version.rb
+++ b/lib/mutineer/version.rb
@@ -2,5 +2,5 @@
 
 module Mutineer
   # Current Mutineer release version.
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end


### PR DESCRIPTION
## What / Why / How

**What.** Cut release **0.11.0**, which ships the `--daemon` backend for Rails mutation testing.

**Why.** The daemon work (#26/#27 Phase 2) merged to main but the version/CHANGELOG weren't bumped — the release-drift bot flagged it (#42). This closes that gap.

**How.** Bump `VERSION` to `0.11.0` and move the CHANGELOG `[Unreleased]` block into a dated `[0.11.0]` section. Merging this, then tagging `v0.11.0`, triggers the tag-driven publish (RubyGems Trusted Publishing + GitHub release).

---

New feature (`--daemon`: one-boot daemon, per-worker DB isolation so `--jobs N` is safe under Rails, coverage-guided) → **minor** bump per semver.

Closes #42 once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.11.0 to ship the `--daemon` backend for Rails mutation testing, closing #42. Bumps `VERSION`, dates the CHANGELOG, and adds missing `[0.11.0]`/`[0.10.0]` link refs; tagging `v0.11.0` publishes the gem and GitHub release.

- **New Features**
  - One-boot daemon with per-worker DB isolation; `--jobs N` is safe under Rails.
  - Coverage-guided execution for faster runs.

<sup>Written for commit 947898b44029ff58e21029aaafaa3e5c95921fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

