### PR TITLE
fix: align --daemon coverage disclosure with reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`--daemon` score disclosure** — stop claiming “no coverage narrowing / lower
+  bound” on every run (narrowing already ships). Warn only when the coverage map
+  is unavailable and the run falls back to the full `--test` set (#48).
+
 ## [0.11.0] - 2026-07-02
 
 ### Added

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -458,26 +458,18 @@ module Mutineer
       reporter.report(out: $stdout, err: $stderr, threshold: config.threshold,
                       format: config.format, output: config.output, baseline: delta)
 
-      # #27/KTD-6: warn (stderr, so it never pollutes json/html) that an external
-      # run's score is not comparable to an in-process run — it has no coverage
-      # narrowing, so uncovered mutants count as survivors, and an infra failure is
-      # scored as a kill (upper bound).
+      # Warn (stderr, so it never pollutes json/html) that an external run's score
+      # is not comparable to an in-process run: no coverage narrowing (uncovered
+      # mutants count as survivors), and an infra failure is scored as a kill
+      # (upper bound). Daemon coverage fallback warnings are emitted from the runner
+      # only when the map is unavailable — not on every --daemon run.
       if config.test_command
         warn "[mutineer] --test-command score is an upper bound, not comparable to an " \
              "in-process run: no coverage narrowing (uncovered mutants count as survivors) " \
              "and an infra failure is scored as a kill."
       end
 
-      # #26/U8: same disclosure as --test-command above — the daemon backend has no
-      # coverage narrowing yet (Phase 2c), so this score is a lower bound (uncovered
-      # mutants count as survivors) and not comparable to an in-process run.
-      if config.daemon
-        warn "[mutineer] --daemon score is a lower bound, not comparable to an " \
-             "in-process run: no coverage narrowing yet (uncovered mutants count as " \
-             "survivors)."
-      end
-
-      # #14: nudge toward the opt-in tier-2 operators (human report only — never
+      # Nudge toward the opt-in tier-2 operators (human report only — never
       # pollute JSON output).
       if !%w[json html].include?(config.format) && (hint = tier2_hint(config.operators))
         puts hint

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -229,13 +229,12 @@ module Mutineer
       end
     end
 
-    # #26/#27 Phase 2a — daemon backend orchestration (serial). Boots the app ONCE in
-    # a persistent subprocess and forks per mutant, restoring the one-boot speed the
-    # Phase 1 subprocess path gives up. Tool-side we build the ready-to-`load` payload
-    # (KTD-2/KTD-3: whole-file reload by default — the spike-proven path) and ship it;
-    # the daemon needs no Prism/mutineer. Serial in 2a (worker-DB isolation +
-    # parallelism is Phase 2b). No coverage narrowing yet (Phase 2c), so every mutant
-    # runs the full `--test` set.
+    # Daemon backend: boot the app once in a persistent subprocess and fork per
+    # mutant. Tool-side we build the ready-to-`load` payload (whole-file reload by
+    # default) and ship it; the daemon needs no Prism/mutineer. Coverage is built
+    # once via a short-lived daemon so each mutant runs only its covering tests.
+    # When jobs > 1, each worker uses its own database (SQLite). Fail-fast forces
+    # serial so the survivor set matches jobs 1.
     #
     # @return [Array(Mutineer::AggregateResult, Hash<String,String>)] aggregate and source map.
     def self.execute_daemon(config, operator_classes)
@@ -243,10 +242,9 @@ module Mutineer
       jobs = filter_since(jobs, source_map, config) if config.since
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
 
-      # #26/U7: build the coverage map once (app-side, via a short-lived daemon) so
-      # each mutant runs ONLY its covering tests and a mutant on an uncovered line is
-      # no_coverage. nil when the build fails — the runners fall back to the full
-      # --test set (no narrowing) rather than mis-scoring everything as no_coverage.
+      # Build the coverage map once (app-side). nil when the build fails — runners
+      # fall back to the full --test set (and emit a stderr warning) rather than
+      # mis-scoring everything as no_coverage.
       coverage_map = daemon_coverage_map(config, abs_tests)
 
       # #26/U6: worker count = resolved --jobs, capped at the job count (no idle
@@ -270,24 +268,16 @@ module Mutineer
       [AggregateResult.new(results + ignored_results), source_map]
     end
 
-    # #26/U7: build the coverage map via a short-lived daemon (boots the app once,
-    # captures per-test coverage app-side, ships the map back). Returns a query-only
+    # Build the coverage map via a short-lived daemon (boots the app once, captures
+    # per-test coverage app-side, ships the map back). Returns a query-only
     # CoverageMap, or nil when the build fails / returns empty — callers then run the
-    # full --test set (no narrowing) rather than mis-scoring. The dedicated daemon
-    # costs one extra boot; correctness over that boot (ponytail — the map is reused
-    # for every mutant).
+    # full --test set. Coverage-build IPC has no wall-clock (same limitation as
+    # in-process build_via_fork). A normal nonempty map scores like in-process;
+    # nil falls back to the full suite (more testing, not comparable).
     #
     # @param config [Mutineer::Config] the run config.
     # @param abs_tests [Array<String>] absolute --test paths.
     # @return [Mutineer::CoverageMap, nil]
-    #
-    # ponytail: the coverage-build IPC read is unbounded (no wall-clock) — a --test
-    # file that infinite-loops during capture wedges this call, mirroring the existing
-    # in-process build_via_fork limitation. A capture timeout is a follow-up. When the
-    # map comes back empty (all captures failed), this returns nil and the run falls
-    # back to the FULL --test set per mutant — so on a total capture failure the daemon
-    # score is an upper bound (more testing), diverging from the in-process no_coverage
-    # scoring for that degenerate case only; a normal (nonempty) map scores identically.
     def self.daemon_coverage_map(config, abs_tests)
       client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests, coverage: true),
                                 app_root: config.project_root).start
@@ -296,13 +286,27 @@ module Mutineer
       ensure
         client.quit
       end
-      return nil unless data && !(data["map"] || {}).empty?
+      unless data && !(data["map"] || {}).empty?
+        warn_daemon_coverage_fallback
+        return nil
+      end
 
       CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
                             project_root: config.project_root)
     rescue DaemonBootError
+      warn_daemon_coverage_fallback
       nil
     end
+
+    # Stderr note when daemon coverage is unavailable (full --test set per mutant).
+    #
+    # @api private
+    # @return [void]
+    def self.warn_daemon_coverage_fallback
+      warn "[mutineer] daemon coverage map unavailable; running every mutant against " \
+           "the full --test set (score not comparable to an in-process run)."
+    end
+    private_class_method :warn_daemon_coverage_fallback
 
     # Serial daemon path: one daemon (worker 0), one mutant at a time. Honors
     # --fail-fast (#21: stop at the first survivor).
@@ -433,8 +437,9 @@ module Mutineer
       [:run, chosen.map { |t| File.expand_path(t, coverage_map.project_root) }]
     end
 
-    # Default per-mutant timeout on the daemon path. Generous because 2a runs the full
-    # `--test` set per mutant (no coverage narrowing until Phase 2c).
+    # Default per-mutant timeout on the daemon path (seconds). Coverage narrowing
+    # usually keeps each job short; this still covers a slow suite or full-suite
+    # fallback when the coverage map is unavailable.
     DAEMON_TIMEOUT = 60
 
     # The boot config the daemon needs to boot the app once: where to boot, the test

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -287,24 +287,26 @@ module Mutineer
         client.quit
       end
       unless data && !(data["map"] || {}).empty?
-        warn_daemon_coverage_fallback
+        reason = data.is_a?(Hash) && data["error"] ? data["error"] : "empty map"
+        warn_daemon_coverage_fallback(reason)
         return nil
       end
 
       CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
                             project_root: config.project_root)
-    rescue DaemonBootError
-      warn_daemon_coverage_fallback
+    rescue DaemonBootError => e
+      warn_daemon_coverage_fallback("#{e.class}: #{e.message}")
       nil
     end
 
     # Stderr note when daemon coverage is unavailable (full --test set per mutant).
     #
     # @api private
+    # @param reason [String] short cause (boot error message, empty map, …).
     # @return [void]
-    def self.warn_daemon_coverage_fallback
-      warn "[mutineer] daemon coverage map unavailable; running every mutant against " \
-           "the full --test set (score not comparable to an in-process run)."
+    def self.warn_daemon_coverage_fallback(reason = "unknown")
+      warn "[mutineer] daemon coverage map unavailable (#{reason}); running every " \
+           "mutant against the full --test set (score not comparable to an in-process run)."
     end
     private_class_method :warn_daemon_coverage_fallback
 

--- a/test/runner_daemon_test.rb
+++ b/test/runner_daemon_test.rb
@@ -64,6 +64,7 @@ class RunnerDaemonTest < Minitest::Test
         assert_nil map
       end
       assert_match(/daemon coverage map unavailable/, err)
+      assert_match(/DaemonBootError/, err)
     end
   end
 end

--- a/test/runner_daemon_test.rb
+++ b/test/runner_daemon_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "minitest/mock"
 require "mutineer/config"
 require "mutineer/runner"
 require "mutineer/cli"
@@ -44,13 +45,25 @@ class RunnerDaemonTest < Minitest::Test
     assert_operator aggregate.killed_count, :>, 0, "weak suite still kills some"
   end
 
-  # #26/U8: the daemon backend has no coverage narrowing yet, so its score is not
-  # comparable to an in-process run — the CLI must disclose that on every --daemon
-  # run, symmetric to the --test-command "upper bound" disclosure (cli.rb:465).
-  def test_cli_discloses_lower_bound_on_daemon_run
+  # Successful daemon coverage narrowing: no stale "lower bound / no narrowing"
+  # caveat. Fallback-only warnings live on Runner.daemon_coverage_map (nil map).
+  def test_cli_does_not_claim_stale_daemon_lower_bound_when_map_ok
     _out, err = capture_io do
       assert_raises(SystemExit) { Mutineer::CLI.execute(config_for("order_test.rb")) }
     end
-    assert_match(/--daemon score is a lower bound/, err)
+    refute_match(/--daemon score is a lower bound/, err)
+    refute_match(/no coverage narrowing yet/, err)
+    refute_match(/daemon coverage map unavailable/, err)
+  end
+
+  def test_daemon_coverage_map_warns_when_unavailable
+    cfg = config_for("order_test.rb")
+    Mutineer::DaemonClient.stub(:new, ->(*) { raise Mutineer::DaemonBootError, "boom" }) do
+      _out, err = capture_io do
+        map = Mutineer::Runner.daemon_coverage_map(cfg, cfg.tests.map { |t| File.expand_path(t, cfg.project_root) })
+        assert_nil map
+      end
+      assert_match(/daemon coverage map unavailable/, err)
+    end
   end
 end


### PR DESCRIPTION
## What
Stop the always-on `--daemon` warning that claims no coverage narrowing / lower-bound score. Narrowing already ships. Warn only when the coverage map is unavailable.

## Why
Users and agents got a false model of the daemon score. README was already correct; CLI and comments lagged.

## How
- Remove always-on CLI lower-bound warn
- Emit stderr when `daemon_coverage_map` returns nil
- Present-tense daemon path docs
- Flip tests to the new contract

Closes #48

## Test plan
- [x] `bundle exec rake test`
- [x] `bundle exec rake yard:strict`
- [ ] `bundle exec rake test:daemon` (CI / local rails fixture)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->