### PR TITLE
fix: harden --threshold for broken runs and bad parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project are documented here. The format is based on
 - **`--daemon` score disclosure** — stop claiming “no coverage narrowing / lower
   bound” on every run (narrowing already ships). Warn only when the coverage map
   is unavailable and the run falls back to the full `--test` set (#48).
+- **`--threshold` CI fidelity** — exit 1 when a positive threshold is set but the
+  run produced only errors/timeouts/uncapturable (nil score with a broken harness)
+  instead of silently green; pure no_coverage / all-ignored still skips the gate
+  (#49). Non-numeric `--threshold` / YAML `threshold` is a usage error (exit 2),
+  not a silent gate-off (#51).
 
 ## [0.11.0] - 2026-07-02
 

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -98,7 +98,15 @@ module Mutineer
         o.on("--since REF") { |v| opts[:since] = v; explicit << :since }
         o.on("--test FILE") { |v| (opts[:tests] ||= []) << v }
         o.on("--operators LIST") { |v| opts[:operators] = v.split(",").map(&:strip); explicit << :operators }
-        o.on("--threshold FLOAT") { |v| opts[:threshold] = v.to_f; explicit << :threshold }
+        o.on("--threshold FLOAT") do |v|
+          f = Float(v, exception: false)
+          if f.nil?
+            warn "mutineer: --threshold requires a number between 0 and 100 (got: #{v.inspect})"
+            exit 2
+          end
+          opts[:threshold] = f
+          explicit << :threshold
+        end
         o.on("--jobs N") { |v| opts[:jobs] = v; explicit << :jobs }
         o.on("--strategy STRAT") { |v| opts[:strategy] = v; explicit << :strategy }
         o.on("--framework NAME") { |v| opts[:framework] = v; explicit << :framework }

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -162,7 +162,13 @@ module Mutineer
       case known_key
       when "operators" then filter_operators(Array(value).map(&:to_s), file_name)
       when "jobs"      then value.to_i
-      when "threshold" then value.to_f
+      when "threshold"
+        f = Float(value, exception: false)
+        if f.nil?
+          raise ConfigError, "#{file_name}: threshold must be a number between 0 and 100 " \
+                             "(got: #{value.inspect})"
+        end
+        f
       when "require"   then Array(value).map(&:to_s)
       when "boot"      then value.to_s
       when "framework" then value.to_s

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -69,12 +69,21 @@ module Mutineer
       verdict(out, threshold) if threshold && threshold.positive?
     end
 
-    # 0 pass / 1 below threshold. Usage errors (exit 2) are the CLI's job.
+    # 0 pass / 1 below threshold or untestable-with-errors. Usage errors (exit 2)
+    # are the CLI's job. When the score is nil (nothing killed or survived), pure
+    # no_coverage / all-ignored / empty still skip the gate; if any mutant was
+    # errored, timed out, or uncapturable, fail the gate so a broken harness
+    # cannot green CI under --threshold.
     def exit_code(threshold:)
       return 0 if threshold.nil? || threshold <= 0
 
       score = @agg.mutation_score
-      return 0 if score.nil? # no testable mutants — gate skipped (warning already emitted)
+      if score.nil?
+        broken = @agg.errored_count + @agg.timeout_count + @agg.uncapturable_count
+        return 1 if @agg.total.positive? && broken.positive?
+
+        return 0 # pure no_coverage / ignored / empty — gate skipped
+      end
 
       score >= threshold ? 0 : 1
     end

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -389,10 +389,36 @@ module Mutineer
                  "#{@agg.ignored_count} ignored excluded"
       if score.nil?
         out.puts "Mutation score: N/A  (no covered mutants)"
-        err.puts "[mutineer] no covered mutations; mutation score is N/A and the threshold check is skipped."
+        if broken_nil_score?
+          err.puts "[mutineer] no covered mutations (#{broken_nil_score_detail}); " \
+                   "threshold gate fails under a positive --threshold (broken harness)."
+        else
+          err.puts "[mutineer] no covered mutations; mutation score is N/A and the threshold check is skipped."
+        end
       else
         out.puts "Mutation score: #{score}%  (killed / (killed + survived); #{excluded})"
       end
+    end
+
+    # True when nil score is due to errors/timeouts/uncapturable (gate must fail).
+    #
+    # @api private
+    # @return [Boolean]
+    def broken_nil_score?
+      @agg.total.positive? &&
+        (@agg.errored_count + @agg.timeout_count + @agg.uncapturable_count).positive?
+    end
+
+    # Human-readable counts for a broken nil-score run.
+    #
+    # @api private
+    # @return [String]
+    def broken_nil_score_detail
+      parts = []
+      parts << "#{@agg.errored_count} errored" if @agg.errored_count.positive?
+      parts << "#{@agg.timeout_count} timeout" if @agg.timeout_count.positive?
+      parts << "#{@agg.uncapturable_count} uncapturable" if @agg.uncapturable_count.positive?
+      parts.join(", ")
     end
 
     # #11: one line per source after the global summary, so a multi-source run
@@ -479,7 +505,13 @@ module Mutineer
     # @return [void]
     def verdict(out, threshold)
       score = @agg.mutation_score
-      return if score.nil?
+      if score.nil?
+        if broken_nil_score?
+          out.puts "FAILED: no covered mutants (#{broken_nil_score_detail}); " \
+                   "threshold #{threshold}% cannot pass with a broken harness"
+        end
+        return
+      end
 
       if score >= threshold
         out.puts "PASSED: #{score}% >= threshold #{threshold}%"

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -45,6 +45,12 @@ class CliTest < Minitest::Test
     assert_includes err, "--jobs requires a positive integer"
   end
 
+  def test_non_numeric_threshold_exits_two
+    _, err, status = mutineer("run", "x.rb", "--threshold", "abc")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "--threshold requires a number"
+  end
+
   def test_unknown_format_exits_two
     _, err, status = mutineer("run", "x.rb", "--format", "csv")
     assert_equal 2, status.exitstatus

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -54,6 +54,13 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_from_file_rejects_non_numeric_threshold
+    with_config("threshold: abc\n") do |path|
+      err = assert_raises(Mutineer::ConfigError) { Config.from_file(path) }
+      assert_match(/threshold must be a number/, err.message)
+    end
+  end
+
   def test_from_file_warns_on_unknown_operator_and_drops_it
     with_config("operators: [arithmetic, bogus]\n") do |path|
       _, err = capture_io { @hash = Config.from_file(path) }

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -75,8 +75,24 @@ class ReporterTest < Minitest::Test
     assert_equal 0, r.exit_code(threshold: 80.0) # 80.0 >= 80.0
   end
 
-  def test_exit_code_nil_score_skips_gate
+  def test_exit_code_nil_score_pure_no_coverage_skips_gate
     assert_equal 0, reporter([Mutineer::Result.no_coverage]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_all_ignored_skips_gate
+    assert_equal 0, reporter([Mutineer::Result.ignored]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_with_errors_fails_gate
+    assert_equal 1, reporter([Mutineer::Result.error("boom")]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_with_timeouts_fails_gate
+    assert_equal 1, reporter([Mutineer::Result.timeout]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_with_uncapturable_fails_gate
+    assert_equal 1, reporter([Mutineer::Result.uncapturable]).exit_code(threshold: 80.0)
   end
 
   # --- rendering / streams ---

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -167,6 +167,17 @@ class ReporterTest < Minitest::Test
     assert_includes err.string, "threshold check is skipped"
   end
 
+  def test_na_score_broken_harness_fails_gate_with_clear_message
+    out = StringIO.new
+    err = StringIO.new
+    reporter([Mutineer::Result.error("boom"), Mutineer::Result.timeout])
+      .report(out: out, err: err, threshold: 80.0)
+    assert_includes out.string, "Mutation score: N/A"
+    assert_includes err.string, "threshold gate fails"
+    assert_includes out.string, "FAILED: no covered mutants"
+    refute_includes err.string, "threshold check is skipped"
+  end
+
   # #11: a multi-source run shows a per-source line per file (sorted by path).
   def test_per_source_block_for_multiple_sources
     other = Mutineer::Subject.new(file: "other.rb", namespace: ["O"], name: :m,


### PR DESCRIPTION
## What
Under a positive `--threshold`, a run with only errors/timeouts/uncapturable no longer exits 0. Non-numeric threshold is a usage error (exit 2), not silent gate-off.

## Why
Silent green CI on a broken harness violates least astonishment.

## How
- `Reporter#exit_code` fails when total > 0 and broken counts > 0 with nil score
- Pure no_coverage / all-ignored still skip the gate
- Strict `Float` parse on CLI and YAML `threshold`

Closes #49
Closes #51

**Stack:** base = PR #48 branch.

## Test plan
- [x] reporter/cli/config tests
- [x] full `rake test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->