### PR TITLE
fix: validate daemon framework/strategy; serial rails without daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project are documented here. The format is based on
   instead of silently green; pure no_coverage / all-ignored still skips the gate
   (#49). Non-numeric `--threshold` / YAML `threshold` is a usage error (exit 2),
   not a silent gate-off (#51).
+- **`--daemon` contracts** — reject `--framework rspec` (exit 2); force
+  `--strategy reload` with a clear warning when redefine was requested (daemon
+  whole-file only) (#50). **In-process `--rails` always serial** unless
+  `--daemon` (only daemon has per-worker DB isolation) (#55).
 
 ## [0.11.0] - 2026-07-02
 

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -315,28 +315,35 @@ module Mutineer
       config.jobs = 1
     end
 
-    # #26/#27 Phase 2 (U8): --daemon selects the persistent-daemon backend (boot once,
-    # fork per mutant, per-worker DB isolation). Two usage errors, both exit 2 (KTD-10):
-    # it cannot be combined with --test-command (choose ONE backend — never silently
-    # pick one), and it requires an app to boot (--rails or --boot). Under Rails,
-    # Config.resolve already keeps --jobs serial unless the user explicitly asks for
-    # parallelism, and each worker gets its own SQLite database on demand — so there is
-    # no "missing worker DB" precondition to check here for SQLite. Postgres worker-DB
-    # provisioning + its missing-DB error (KTD-9) arrives with the Postgres adapter (U10).
+    # --daemon selects the persistent-daemon backend (boot once, fork per mutant,
+    # per-worker DB isolation on SQLite). Usage errors exit 2: cannot combine with
+    # --test-command; requires --rails or --boot; minitest only; reload strategy only
+    # (redefine needs a shared VM surgical path the daemon does not ship).
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
-    # @param explicit [Set<Symbol>] explicit CLI fields.
+    # @param _explicit [Set<Symbol>] unused; kept for call-site compatibility.
     # @return [void]
     def self.validate_daemon!(config, _explicit = Set.new)
       if config.test_command
         warn "mutineer: choose one backend — --daemon and --test-command cannot be combined"
         exit 2
       end
-      return if config.rails || config.boot
+      unless config.rails || config.boot
+        warn "mutineer: --daemon needs an app to boot; add --rails (or --boot FILE)"
+        exit 2
+      end
+      if config.framework == "rspec"
+        warn "mutineer: --daemon supports only --framework minitest " \
+             "(rspec is not implemented on the daemon path yet)"
+        exit 2
+      end
+      return if config.strategy == "reload"
 
-      warn "mutineer: --daemon needs an app to boot; add --rails (or --boot FILE)"
-      exit 2
+      # --rails defaults strategy to redefine; daemon always whole-file loads.
+      warn "[mutineer] --daemon uses --strategy reload " \
+           "(redefine is not supported on the daemon path); forcing reload."
+      config.strategy = "reload"
     end
 
     # --since needs a real git repo and a resolvable ref; either failure is a

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -256,21 +256,21 @@ module Mutineer
       end
 
       validate_test_command!(config) if config.test_command
-      validate_daemon!(config, explicit) if config.daemon
 
       validate_since!(config) if config.since
       preflight_output!(config.output) if config.output
       preflight_baseline!(config.baseline) if config.baseline
 
-      # #11: when --test is omitted, infer each source's test by convention so the
-      # boot-once/fork-per-test core (which pairs empirically by coverage) gets a
-      # populated config.tests. Runs after every flag/usage check above so a
-      # mistyped flag still reports the flag; skipped under --dry-run (no tests
-      # needed). validate_paths! then sees the inferred (real) tests.
+      # When --test is omitted, infer each source's test by convention. Autopair
+      # also re-detects framework from inferred tests when --framework was not set.
       autopair!(config, explicit) unless config.dry_run
 
-      # Boot mode does no coverage selection — every mutant runs the given tests —
-      # so at least one --test file is mandatory (there is nothing to select from).
+      # Daemon validation runs AFTER autopair so auto-inferred *_spec.rb tests
+      # cannot bypass the RSpec rejection (framework would still be minitest if we
+      # validated before discovery).
+      validate_daemon!(config) if config.daemon
+
+      # Boot mode needs at least one --test file (nothing to select from otherwise).
       if config.boot && config.tests.empty?
         warn "mutineer: --boot/--rails requires at least one --test file"
         exit 2
@@ -322,9 +322,8 @@ module Mutineer
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
-    # @param _explicit [Set<Symbol>] unused; kept for call-site compatibility.
     # @return [void]
-    def self.validate_daemon!(config, _explicit = Set.new)
+    def self.validate_daemon!(config)
       if config.test_command
         warn "mutineer: choose one backend — --daemon and --test-command cannot be combined"
         exit 2

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -113,16 +113,13 @@ module Mutineer
       config = new(**merged)
 
       # --rails sugar: boot config/environment and prefer the surgical (redefine)
-      # strategy, which avoids writing tempfiles into the app tree and Zeitwerk
-      # reload hazards. An explicit --strategy always wins.
+      # strategy for the in-process path (avoids app-tree tempfiles / Zeitwerk
+      # hazards). An explicit --strategy always wins. In-process --rails shares
+      # one test database — force serial unless --daemon (per-worker SQLite DBs).
       if config.rails
         config.boot ||= "config/environment"
         config.strategy = "redefine" unless explicit.include?(:strategy)
-        # #12: parallel mutant forks share one database; transactional-fixture
-        # setup/teardown across processes contends and deadlocks. Default to
-        # serial under --rails; an explicit --jobs N opts back into parallelism
-        # (with the per-worker DB-isolation that implies).
-        config.jobs = 1 unless explicit.include?(:jobs)
+        config.jobs = 1 unless config.daemon
       end
 
       # Auto-detect the framework only when neither CLI nor config file set it

--- a/test/cli_daemon_test.rb
+++ b/test/cli_daemon_test.rb
@@ -50,6 +50,26 @@ class CliDaemonTest < Minitest::Test
     assert_includes err, "supports only --framework minitest"
   end
 
+  # Framework re-detect after autopair: auto-inferred *_spec.rb tests must not
+  # bypass the daemon RSpec guard when the user never passed --framework.
+  def test_daemon_rejects_auto_detected_rspec_after_autopair
+    require "fileutils"
+    Dir.mktmpdir("mutineer-rspec-auto") do |dir|
+      FileUtils.mkdir_p(File.join(dir, "lib"))
+      FileUtils.mkdir_p(File.join(dir, "spec"))
+      File.write(File.join(dir, "lib", "widget.rb"), "class Widget; def x; 1; end; end\n")
+      File.write(File.join(dir, "spec", "widget_spec.rb"),
+                 "RSpec.describe(Widget) { it('x') { expect(1).to eq(1) } }\n")
+      _, err, status = Open3.capture3(
+        RbConfig.ruby, "-I#{File.join(ROOT, 'lib')}", BIN,
+        "run", "lib/widget.rb", "--daemon", "--boot", "lib/widget.rb",
+        chdir: dir
+      )
+      assert_equal 2, status.exitstatus, err
+      assert_includes err, "supports only --framework minitest"
+    end
+  end
+
   def test_daemon_forces_reload_when_redefine_requested
     _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon", "--rails",
                               "--strategy", "redefine")

--- a/test/cli_daemon_test.rb
+++ b/test/cli_daemon_test.rb
@@ -43,6 +43,22 @@ class CliDaemonTest < Minitest::Test
     refute_equal 0, status.exitstatus
   end
 
+  def test_daemon_with_rspec_is_a_usage_error
+    _, err, status = mutineer("run", "x.rb", "--test", "t_spec.rb", "--daemon", "--rails",
+                              "--framework", "rspec")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "supports only --framework minitest"
+  end
+
+  def test_daemon_forces_reload_when_redefine_requested
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon", "--rails",
+                              "--strategy", "redefine")
+    assert_includes err, "forcing reload"
+    refute_includes err, "supports only --framework"
+    # Still fails later (no real app in tmpdir), not as a strategy usage hard-exit.
+    refute_equal 0, status.exitstatus
+  end
+
   # --daemon is settable in .mutineer.yml (KNOWN_KEYS) with boolean coercion.
   def test_daemon_is_a_known_config_key_with_boolean_coercion
     assert_includes Mutineer::KNOWN_KEYS, "daemon"

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -167,15 +167,18 @@ class ConfigTest < Minitest::Test
     assert_equal true, Config.resolve({ verbose: true }, {}, Set.new).verbose
   end
 
-  # #12: --rails defaults to serial (one DB, parallel forks deadlock); explicit wins.
+  # In-process --rails shares one DB; always serial. --daemon may use --jobs N.
   def test_resolve_rails_defaults_jobs_to_one
     assert_equal 1, Config.resolve({ rails: true }, {}, Set.new).jobs
   end
 
-  def test_resolve_rails_respects_explicit_jobs
-    # jobs is normalized to an Integer later in CLI.validate!; resolve keeps it as
-    # given. The point: --rails does NOT clobber an explicit --jobs.
+  def test_resolve_rails_forces_serial_even_when_jobs_explicit
     cfg = Config.resolve({ rails: true, jobs: "4" }, {}, Set[:jobs])
+    assert_equal 1, cfg.jobs
+  end
+
+  def test_resolve_rails_daemon_keeps_explicit_jobs
+    cfg = Config.resolve({ rails: true, daemon: true, jobs: "4" }, {}, Set[:jobs])
     assert_equal "4", cfg.jobs
   end
 


### PR DESCRIPTION
## What
Reject `--daemon` + RSpec. Force reload under daemon when redefine was requested. In-process `--rails` always serial unless `--daemon`.

## Why
RSpec on daemon became all-error. Strategy was silently ignored. Config falsely implied worker-DB isolation for in-process rails jobs.

Closes #50
Closes #55

**Stack:** base = #49-51 branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->