### PR TITLE
fix: force serial in-process pool under --fail-fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`--daemon` score disclosure** — stop claiming “no coverage narrowing / lower
+  bound” on every run (narrowing already ships). Warn only when the coverage map
+  is unavailable and the run falls back to the full `--test` set (#48).
+
 ## [0.11.0] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project are documented here. The format is based on
 - **Isolation timeout** — kill the child process group and honor a clean exit
   that races the deadline (not always timeout) (#52). **External backend** —
   signal death is `error`, not `killed` (#53).
+- **`--fail-fast` is serial** on the in-process path (matches daemon) so the
+  survivor set is deterministic under any `--jobs` (#54).
 
 ## [0.11.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project are documented here. The format is based on
 - **`--daemon` score disclosure** — stop claiming “no coverage narrowing / lower
   bound” on every run (narrowing already ships). Warn only when the coverage map
   is unavailable and the run falls back to the full `--test` set (#48).
+- **`--threshold` CI fidelity** — exit 1 when a positive threshold is set but the
+  run produced only errors/timeouts/uncapturable (nil score with a broken harness)
+  instead of silently green; pure no_coverage / all-ignored still skips the gate
+  (#49). Non-numeric `--threshold` / YAML `threshold` is a usage error (exit 2),
+  not a silent gate-off (#51).
 
 ## [0.11.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project are documented here. The format is based on
   `--strategy reload` with a clear warning when redefine was requested (daemon
   whole-file only) (#50). **In-process `--rails` always serial** unless
   `--daemon` (only daemon has per-worker DB isolation) (#55).
+- **Isolation timeout** — kill the child process group and honor a clean exit
+  that races the deadline (not always timeout) (#52). **External backend** —
+  signal death is `error`, not `killed` (#53).
 
 ## [0.11.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project are documented here. The format is based on
   instead of silently green; pure no_coverage / all-ignored still skips the gate
   (#49). Non-numeric `--threshold` / YAML `threshold` is a usage error (exit 2),
   not a silent gate-off (#51).
+- **`--daemon` contracts** — reject `--framework rspec` (exit 2); force
+  `--strategy reload` with a clear warning when redefine was requested (daemon
+  whole-file only) (#50). **In-process `--rails` always serial** unless
+  `--daemon` (only daemon has per-worker DB isolation) (#55).
 
 ## [0.11.0] - 2026-07-02
 

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -98,7 +98,15 @@ module Mutineer
         o.on("--since REF") { |v| opts[:since] = v; explicit << :since }
         o.on("--test FILE") { |v| (opts[:tests] ||= []) << v }
         o.on("--operators LIST") { |v| opts[:operators] = v.split(",").map(&:strip); explicit << :operators }
-        o.on("--threshold FLOAT") { |v| opts[:threshold] = v.to_f; explicit << :threshold }
+        o.on("--threshold FLOAT") do |v|
+          f = Float(v, exception: false)
+          if f.nil?
+            warn "mutineer: --threshold requires a number between 0 and 100 (got: #{v.inspect})"
+            exit 2
+          end
+          opts[:threshold] = f
+          explicit << :threshold
+        end
         o.on("--jobs N") { |v| opts[:jobs] = v; explicit << :jobs }
         o.on("--strategy STRAT") { |v| opts[:strategy] = v; explicit << :strategy }
         o.on("--framework NAME") { |v| opts[:framework] = v; explicit << :framework }

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -315,28 +315,35 @@ module Mutineer
       config.jobs = 1
     end
 
-    # #26/#27 Phase 2 (U8): --daemon selects the persistent-daemon backend (boot once,
-    # fork per mutant, per-worker DB isolation). Two usage errors, both exit 2 (KTD-10):
-    # it cannot be combined with --test-command (choose ONE backend — never silently
-    # pick one), and it requires an app to boot (--rails or --boot). Under Rails,
-    # Config.resolve already keeps --jobs serial unless the user explicitly asks for
-    # parallelism, and each worker gets its own SQLite database on demand — so there is
-    # no "missing worker DB" precondition to check here for SQLite. Postgres worker-DB
-    # provisioning + its missing-DB error (KTD-9) arrives with the Postgres adapter (U10).
+    # --daemon selects the persistent-daemon backend (boot once, fork per mutant,
+    # per-worker DB isolation on SQLite). Usage errors exit 2: cannot combine with
+    # --test-command; requires --rails or --boot; minitest only; reload strategy only
+    # (redefine needs a shared VM surgical path the daemon does not ship).
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
-    # @param explicit [Set<Symbol>] explicit CLI fields.
+    # @param _explicit [Set<Symbol>] unused; kept for call-site compatibility.
     # @return [void]
     def self.validate_daemon!(config, _explicit = Set.new)
       if config.test_command
         warn "mutineer: choose one backend — --daemon and --test-command cannot be combined"
         exit 2
       end
-      return if config.rails || config.boot
+      unless config.rails || config.boot
+        warn "mutineer: --daemon needs an app to boot; add --rails (or --boot FILE)"
+        exit 2
+      end
+      if config.framework == "rspec"
+        warn "mutineer: --daemon supports only --framework minitest " \
+             "(rspec is not implemented on the daemon path yet)"
+        exit 2
+      end
+      return if config.strategy == "reload"
 
-      warn "mutineer: --daemon needs an app to boot; add --rails (or --boot FILE)"
-      exit 2
+      # --rails defaults strategy to redefine; daemon always whole-file loads.
+      warn "[mutineer] --daemon uses --strategy reload " \
+           "(redefine is not supported on the daemon path); forcing reload."
+      config.strategy = "reload"
     end
 
     # --since needs a real git repo and a resolvable ref; either failure is a

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -458,26 +458,18 @@ module Mutineer
       reporter.report(out: $stdout, err: $stderr, threshold: config.threshold,
                       format: config.format, output: config.output, baseline: delta)
 
-      # #27/KTD-6: warn (stderr, so it never pollutes json/html) that an external
-      # run's score is not comparable to an in-process run — it has no coverage
-      # narrowing, so uncovered mutants count as survivors, and an infra failure is
-      # scored as a kill (upper bound).
+      # Warn (stderr, so it never pollutes json/html) that an external run's score
+      # is not comparable to an in-process run: no coverage narrowing (uncovered
+      # mutants count as survivors), and an infra failure is scored as a kill
+      # (upper bound). Daemon coverage fallback warnings are emitted from the runner
+      # only when the map is unavailable — not on every --daemon run.
       if config.test_command
         warn "[mutineer] --test-command score is an upper bound, not comparable to an " \
              "in-process run: no coverage narrowing (uncovered mutants count as survivors) " \
              "and an infra failure is scored as a kill."
       end
 
-      # #26/U8: same disclosure as --test-command above — the daemon backend has no
-      # coverage narrowing yet (Phase 2c), so this score is a lower bound (uncovered
-      # mutants count as survivors) and not comparable to an in-process run.
-      if config.daemon
-        warn "[mutineer] --daemon score is a lower bound, not comparable to an " \
-             "in-process run: no coverage narrowing yet (uncovered mutants count as " \
-             "survivors)."
-      end
-
-      # #14: nudge toward the opt-in tier-2 operators (human report only — never
+      # Nudge toward the opt-in tier-2 operators (human report only — never
       # pollute JSON output).
       if !%w[json html].include?(config.format) && (hint = tier2_hint(config.operators))
         puts hint

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -256,21 +256,21 @@ module Mutineer
       end
 
       validate_test_command!(config) if config.test_command
-      validate_daemon!(config, explicit) if config.daemon
 
       validate_since!(config) if config.since
       preflight_output!(config.output) if config.output
       preflight_baseline!(config.baseline) if config.baseline
 
-      # #11: when --test is omitted, infer each source's test by convention so the
-      # boot-once/fork-per-test core (which pairs empirically by coverage) gets a
-      # populated config.tests. Runs after every flag/usage check above so a
-      # mistyped flag still reports the flag; skipped under --dry-run (no tests
-      # needed). validate_paths! then sees the inferred (real) tests.
+      # When --test is omitted, infer each source's test by convention. Autopair
+      # also re-detects framework from inferred tests when --framework was not set.
       autopair!(config, explicit) unless config.dry_run
 
-      # Boot mode does no coverage selection — every mutant runs the given tests —
-      # so at least one --test file is mandatory (there is nothing to select from).
+      # Daemon validation runs AFTER autopair so auto-inferred *_spec.rb tests
+      # cannot bypass the RSpec rejection (framework would still be minitest if we
+      # validated before discovery).
+      validate_daemon!(config) if config.daemon
+
+      # Boot mode needs at least one --test file (nothing to select from otherwise).
       if config.boot && config.tests.empty?
         warn "mutineer: --boot/--rails requires at least one --test file"
         exit 2
@@ -322,9 +322,8 @@ module Mutineer
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
-    # @param _explicit [Set<Symbol>] unused; kept for call-site compatibility.
     # @return [void]
-    def self.validate_daemon!(config, _explicit = Set.new)
+    def self.validate_daemon!(config)
       if config.test_command
         warn "mutineer: choose one backend — --daemon and --test-command cannot be combined"
         exit 2

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -172,6 +172,7 @@ module Mutineer
       when "rails"     then value == true || value.to_s == "true"
       when "daemon"    then value == true || value.to_s == "true"
       when "verbose"   then value == true || value.to_s == "true"
+      when "fail_fast" then value == true || value.to_s == "true"
       when "ignore"    then Array(value).map(&:to_s)
       when "baseline"  then value.to_s
       when "test_command" then value.to_s

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -113,16 +113,13 @@ module Mutineer
       config = new(**merged)
 
       # --rails sugar: boot config/environment and prefer the surgical (redefine)
-      # strategy, which avoids writing tempfiles into the app tree and Zeitwerk
-      # reload hazards. An explicit --strategy always wins.
+      # strategy for the in-process path (avoids app-tree tempfiles / Zeitwerk
+      # hazards). An explicit --strategy always wins. In-process --rails shares
+      # one test database — force serial unless --daemon (per-worker SQLite DBs).
       if config.rails
         config.boot ||= "config/environment"
         config.strategy = "redefine" unless explicit.include?(:strategy)
-        # #12: parallel mutant forks share one database; transactional-fixture
-        # setup/teardown across processes contends and deadlocks. Default to
-        # serial under --rails; an explicit --jobs N opts back into parallelism
-        # (with the per-worker DB-isolation that implies).
-        config.jobs = 1 unless explicit.include?(:jobs)
+        config.jobs = 1 unless config.daemon
       end
 
       # Auto-detect the framework only when neither CLI nor config file set it

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -162,7 +162,13 @@ module Mutineer
       case known_key
       when "operators" then filter_operators(Array(value).map(&:to_s), file_name)
       when "jobs"      then value.to_i
-      when "threshold" then value.to_f
+      when "threshold"
+        f = Float(value, exception: false)
+        if f.nil?
+          raise ConfigError, "#{file_name}: threshold must be a number between 0 and 100 " \
+                             "(got: #{value.inspect})"
+        end
+        f
       when "require"   then Array(value).map(&:to_s)
       when "boot"      then value.to_s
       when "framework" then value.to_s

--- a/lib/mutineer/daemon_server.rb
+++ b/lib/mutineer/daemon_server.rb
@@ -222,7 +222,14 @@ module Mutineer
             rescue Errno::ESRCH, Errno::EPERM
               Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
             end
-            Process.waitpid(pid) rescue nil # rubocop:disable Style/RescueModifier
+            begin
+              _reaped, status = Process.waitpid2(pid)
+              if status && status.exited? && !status.signaled?
+                return { 0 => "survived", 1 => "killed" }.fetch(status.exitstatus, "error")
+              end
+            rescue Errno::ECHILD
+              # already reaped
+            end
             return "timeout"
           end
           sleep POLL

--- a/lib/mutineer/external_backend.rb
+++ b/lib/mutineer/external_backend.rb
@@ -62,6 +62,12 @@ module Mutineer
         Result.timeout
       else # :exited
         return Result.survived if code&.zero?
+        # Signal death (nil exitstatus) is infrastructure, not a suite assertion
+        # failure — match Isolation/daemon (error), do not inflate kill rate.
+        if code.nil?
+          warn output if verbose && !output.empty?
+          return Result.error("test-command terminated by signal")
+        end
 
         warn output if verbose && !output.empty?
         Result.killed
@@ -151,7 +157,13 @@ module Mutineer
           rescue Errno::ESRCH, Errno::EPERM
             Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
           end
-          Process.waitpid(pid) rescue nil # rubocop:disable Style/RescueModifier
+          begin
+            _reaped, status = Process.waitpid2(pid)
+            # Finished cleanly between poll and kill — honor real exit code.
+            return [:exited, status.exitstatus] if status && status.exited? && !status.signaled?
+          rescue Errno::ECHILD
+            # already reaped
+          end
           return [:timeout, nil]
         end
         sleep POLL

--- a/lib/mutineer/isolation.rb
+++ b/lib/mutineer/isolation.rb
@@ -31,6 +31,9 @@ module Mutineer
     # @return [Mutineer::Result] result from the child process.
     def self.run(timeout: DEFAULT_TIMEOUT)
       pid = fork do
+        # Own process group so a timeout kill can reap grandchildren (match
+        # daemon/external backends). Best-effort: if setpgid fails, kill the pid.
+        Process.setpgid(0, 0) rescue nil # rubocop:disable Style/RescueModifier
         code = 0
         begin
           result = yield
@@ -48,20 +51,27 @@ module Mutineer
         exit!(code)
       end
 
-      # Single-threaded deadline poll (R2): we are the ONLY caller of waitpid
-      # on this pid, so we never reap-then-kill. We SIGKILL only after WNOHANG
-      # shows the child is still alive past the deadline — so the kill can
-      # never hit a reaped/recycled pid. Timeout is a parent-side fact
-      # (deadline reached), not status.signaled? (which is true for ANY signal
-      # death, e.g. SIGSEGV).
+      # Single-threaded deadline poll: we are the ONLY caller of waitpid on this
+      # pid, so we never reap-then-kill. SIGKILL the process group only after
+      # WNOHANG shows the child is still alive past the deadline.
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
       loop do
         reaped, status = Process.waitpid2(pid, Process::WNOHANG)
         return decode(status) if reaped
 
         if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-          Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
-          Process.waitpid(pid) rescue nil # rubocop:disable Style/RescueModifier
+          begin
+            Process.kill(:KILL, -pid)
+          rescue Errno::ESRCH, Errno::EPERM
+            Process.kill(:KILL, pid) rescue nil # rubocop:disable Style/RescueModifier
+          end
+          begin
+            _reaped, status = Process.waitpid2(pid)
+            # Child may have finished cleanly between WNOHANG and kill; honor it.
+            return decode(status) if status && status.exited? && !status.signaled?
+          rescue Errno::ECHILD
+            # already reaped
+          end
           return Result.timeout
         end
         sleep 0.005

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -69,12 +69,21 @@ module Mutineer
       verdict(out, threshold) if threshold && threshold.positive?
     end
 
-    # 0 pass / 1 below threshold. Usage errors (exit 2) are the CLI's job.
+    # 0 pass / 1 below threshold or untestable-with-errors. Usage errors (exit 2)
+    # are the CLI's job. When the score is nil (nothing killed or survived), pure
+    # no_coverage / all-ignored / empty still skip the gate; if any mutant was
+    # errored, timed out, or uncapturable, fail the gate so a broken harness
+    # cannot green CI under --threshold.
     def exit_code(threshold:)
       return 0 if threshold.nil? || threshold <= 0
 
       score = @agg.mutation_score
-      return 0 if score.nil? # no testable mutants — gate skipped (warning already emitted)
+      if score.nil?
+        broken = @agg.errored_count + @agg.timeout_count + @agg.uncapturable_count
+        return 1 if @agg.total.positive? && broken.positive?
+
+        return 0 # pure no_coverage / ignored / empty — gate skipped
+      end
 
       score >= threshold ? 0 : 1
     end

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -389,10 +389,36 @@ module Mutineer
                  "#{@agg.ignored_count} ignored excluded"
       if score.nil?
         out.puts "Mutation score: N/A  (no covered mutants)"
-        err.puts "[mutineer] no covered mutations; mutation score is N/A and the threshold check is skipped."
+        if broken_nil_score?
+          err.puts "[mutineer] no covered mutations (#{broken_nil_score_detail}); " \
+                   "threshold gate fails under a positive --threshold (broken harness)."
+        else
+          err.puts "[mutineer] no covered mutations; mutation score is N/A and the threshold check is skipped."
+        end
       else
         out.puts "Mutation score: #{score}%  (killed / (killed + survived); #{excluded})"
       end
+    end
+
+    # True when nil score is due to errors/timeouts/uncapturable (gate must fail).
+    #
+    # @api private
+    # @return [Boolean]
+    def broken_nil_score?
+      @agg.total.positive? &&
+        (@agg.errored_count + @agg.timeout_count + @agg.uncapturable_count).positive?
+    end
+
+    # Human-readable counts for a broken nil-score run.
+    #
+    # @api private
+    # @return [String]
+    def broken_nil_score_detail
+      parts = []
+      parts << "#{@agg.errored_count} errored" if @agg.errored_count.positive?
+      parts << "#{@agg.timeout_count} timeout" if @agg.timeout_count.positive?
+      parts << "#{@agg.uncapturable_count} uncapturable" if @agg.uncapturable_count.positive?
+      parts.join(", ")
     end
 
     # #11: one line per source after the global summary, so a multi-source run
@@ -479,7 +505,13 @@ module Mutineer
     # @return [void]
     def verdict(out, threshold)
       score = @agg.mutation_score
-      return if score.nil?
+      if score.nil?
+        if broken_nil_score?
+          out.puts "FAILED: no covered mutants (#{broken_nil_score_detail}); " \
+                   "threshold #{threshold}% cannot pass with a broken harness"
+        end
+        return
+      end
 
       if score >= threshold
         out.puts "PASSED: #{score}% >= threshold #{threshold}%"

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -229,13 +229,12 @@ module Mutineer
       end
     end
 
-    # #26/#27 Phase 2a — daemon backend orchestration (serial). Boots the app ONCE in
-    # a persistent subprocess and forks per mutant, restoring the one-boot speed the
-    # Phase 1 subprocess path gives up. Tool-side we build the ready-to-`load` payload
-    # (KTD-2/KTD-3: whole-file reload by default — the spike-proven path) and ship it;
-    # the daemon needs no Prism/mutineer. Serial in 2a (worker-DB isolation +
-    # parallelism is Phase 2b). No coverage narrowing yet (Phase 2c), so every mutant
-    # runs the full `--test` set.
+    # Daemon backend: boot the app once in a persistent subprocess and fork per
+    # mutant. Tool-side we build the ready-to-`load` payload (whole-file reload by
+    # default) and ship it; the daemon needs no Prism/mutineer. Coverage is built
+    # once via a short-lived daemon so each mutant runs only its covering tests.
+    # When jobs > 1, each worker uses its own database (SQLite). Fail-fast forces
+    # serial so the survivor set matches jobs 1.
     #
     # @return [Array(Mutineer::AggregateResult, Hash<String,String>)] aggregate and source map.
     def self.execute_daemon(config, operator_classes)
@@ -243,10 +242,9 @@ module Mutineer
       jobs = filter_since(jobs, source_map, config) if config.since
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
 
-      # #26/U7: build the coverage map once (app-side, via a short-lived daemon) so
-      # each mutant runs ONLY its covering tests and a mutant on an uncovered line is
-      # no_coverage. nil when the build fails — the runners fall back to the full
-      # --test set (no narrowing) rather than mis-scoring everything as no_coverage.
+      # Build the coverage map once (app-side). nil when the build fails — runners
+      # fall back to the full --test set (and emit a stderr warning) rather than
+      # mis-scoring everything as no_coverage.
       coverage_map = daemon_coverage_map(config, abs_tests)
 
       # #26/U6: worker count = resolved --jobs, capped at the job count (no idle
@@ -270,24 +268,16 @@ module Mutineer
       [AggregateResult.new(results + ignored_results), source_map]
     end
 
-    # #26/U7: build the coverage map via a short-lived daemon (boots the app once,
-    # captures per-test coverage app-side, ships the map back). Returns a query-only
+    # Build the coverage map via a short-lived daemon (boots the app once, captures
+    # per-test coverage app-side, ships the map back). Returns a query-only
     # CoverageMap, or nil when the build fails / returns empty — callers then run the
-    # full --test set (no narrowing) rather than mis-scoring. The dedicated daemon
-    # costs one extra boot; correctness over that boot (ponytail — the map is reused
-    # for every mutant).
+    # full --test set. Coverage-build IPC has no wall-clock (same limitation as
+    # in-process build_via_fork). A normal nonempty map scores like in-process;
+    # nil falls back to the full suite (more testing, not comparable).
     #
     # @param config [Mutineer::Config] the run config.
     # @param abs_tests [Array<String>] absolute --test paths.
     # @return [Mutineer::CoverageMap, nil]
-    #
-    # ponytail: the coverage-build IPC read is unbounded (no wall-clock) — a --test
-    # file that infinite-loops during capture wedges this call, mirroring the existing
-    # in-process build_via_fork limitation. A capture timeout is a follow-up. When the
-    # map comes back empty (all captures failed), this returns nil and the run falls
-    # back to the FULL --test set per mutant — so on a total capture failure the daemon
-    # score is an upper bound (more testing), diverging from the in-process no_coverage
-    # scoring for that degenerate case only; a normal (nonempty) map scores identically.
     def self.daemon_coverage_map(config, abs_tests)
       client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests, coverage: true),
                                 app_root: config.project_root).start
@@ -296,13 +286,27 @@ module Mutineer
       ensure
         client.quit
       end
-      return nil unless data && !(data["map"] || {}).empty?
+      unless data && !(data["map"] || {}).empty?
+        warn_daemon_coverage_fallback
+        return nil
+      end
 
       CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
                             project_root: config.project_root)
     rescue DaemonBootError
+      warn_daemon_coverage_fallback
       nil
     end
+
+    # Stderr note when daemon coverage is unavailable (full --test set per mutant).
+    #
+    # @api private
+    # @return [void]
+    def self.warn_daemon_coverage_fallback
+      warn "[mutineer] daemon coverage map unavailable; running every mutant against " \
+           "the full --test set (score not comparable to an in-process run)."
+    end
+    private_class_method :warn_daemon_coverage_fallback
 
     # Serial daemon path: one daemon (worker 0), one mutant at a time. Honors
     # --fail-fast (#21: stop at the first survivor).
@@ -433,8 +437,9 @@ module Mutineer
       [:run, chosen.map { |t| File.expand_path(t, coverage_map.project_root) }]
     end
 
-    # Default per-mutant timeout on the daemon path. Generous because 2a runs the full
-    # `--test` set per mutant (no coverage narrowing until Phase 2c).
+    # Default per-mutant timeout on the daemon path (seconds). Coverage narrowing
+    # usually keeps each job short; this still covers a slow suite or full-suite
+    # fallback when the coverage map is unavailable.
     DAEMON_TIMEOUT = 60
 
     # The boot config the daemon needs to boot the app once: where to boot, the test

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -287,24 +287,26 @@ module Mutineer
         client.quit
       end
       unless data && !(data["map"] || {}).empty?
-        warn_daemon_coverage_fallback
+        reason = data.is_a?(Hash) && data["error"] ? data["error"] : "empty map"
+        warn_daemon_coverage_fallback(reason)
         return nil
       end
 
       CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
                             project_root: config.project_root)
-    rescue DaemonBootError
-      warn_daemon_coverage_fallback
+    rescue DaemonBootError => e
+      warn_daemon_coverage_fallback("#{e.class}: #{e.message}")
       nil
     end
 
     # Stderr note when daemon coverage is unavailable (full --test set per mutant).
     #
     # @api private
+    # @param reason [String] short cause (boot error message, empty map, …).
     # @return [void]
-    def self.warn_daemon_coverage_fallback
-      warn "[mutineer] daemon coverage map unavailable; running every mutant against " \
-           "the full --test set (score not comparable to an in-process run)."
+    def self.warn_daemon_coverage_fallback(reason = "unknown")
+      warn "[mutineer] daemon coverage map unavailable (#{reason}); running every " \
+           "mutant against the full --test set (score not comparable to an in-process run)."
     end
     private_class_method :warn_daemon_coverage_fallback
 

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -112,13 +112,15 @@ module Mutineer
       sweep_orphans(dirs)
 
       strategy = config.strategy
+      # Fail-fast must be serial: a parallel stop_when fires on the first survivor
+      # by wall-clock, not input order, so the survivor set would diverge from
+      # --jobs 1 (daemon already forces serial for the same reason).
+      jobs_n = config.fail_fast ? 1 : config.jobs
       results =
         begin
           framework = config.framework
-          # #21: --fail-fast stops scheduling new mutants after the first survivor;
-          # in-flight workers drain, unscheduled jobs stay nil (dropped below).
           stop_when = config.fail_fast ? ->(r) { r.survived? } : nil
-          bare = WorkerPool.new(config.jobs).run(jobs, stop_when: stop_when) do |subject, mutation|
+          bare = WorkerPool.new(jobs_n).run(jobs, stop_when: stop_when) do |subject, mutation|
             run(mutation, source_file: subject.file, coverage_map: coverage_map,
                 subject: subject, strategy: strategy, rails: config.rails, framework: framework)
           end

--- a/test/cli_daemon_test.rb
+++ b/test/cli_daemon_test.rb
@@ -50,6 +50,26 @@ class CliDaemonTest < Minitest::Test
     assert_includes err, "supports only --framework minitest"
   end
 
+  # Framework re-detect after autopair: auto-inferred *_spec.rb tests must not
+  # bypass the daemon RSpec guard when the user never passed --framework.
+  def test_daemon_rejects_auto_detected_rspec_after_autopair
+    require "fileutils"
+    Dir.mktmpdir("mutineer-rspec-auto") do |dir|
+      FileUtils.mkdir_p(File.join(dir, "lib"))
+      FileUtils.mkdir_p(File.join(dir, "spec"))
+      File.write(File.join(dir, "lib", "widget.rb"), "class Widget; def x; 1; end; end\n")
+      File.write(File.join(dir, "spec", "widget_spec.rb"),
+                 "RSpec.describe(Widget) { it('x') { expect(1).to eq(1) } }\n")
+      _, err, status = Open3.capture3(
+        RbConfig.ruby, "-I#{File.join(ROOT, 'lib')}", BIN,
+        "run", "lib/widget.rb", "--daemon", "--boot", "lib/widget.rb",
+        chdir: dir
+      )
+      assert_equal 2, status.exitstatus, err
+      assert_includes err, "supports only --framework minitest"
+    end
+  end
+
   def test_daemon_forces_reload_when_redefine_requested
     _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon", "--rails",
                               "--strategy", "redefine")

--- a/test/cli_daemon_test.rb
+++ b/test/cli_daemon_test.rb
@@ -43,6 +43,22 @@ class CliDaemonTest < Minitest::Test
     refute_equal 0, status.exitstatus
   end
 
+  def test_daemon_with_rspec_is_a_usage_error
+    _, err, status = mutineer("run", "x.rb", "--test", "t_spec.rb", "--daemon", "--rails",
+                              "--framework", "rspec")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "supports only --framework minitest"
+  end
+
+  def test_daemon_forces_reload_when_redefine_requested
+    _, err, status = mutineer("run", "x.rb", "--test", "t.rb", "--daemon", "--rails",
+                              "--strategy", "redefine")
+    assert_includes err, "forcing reload"
+    refute_includes err, "supports only --framework"
+    # Still fails later (no real app in tmpdir), not as a strategy usage hard-exit.
+    refute_equal 0, status.exitstatus
+  end
+
   # --daemon is settable in .mutineer.yml (KNOWN_KEYS) with boolean coercion.
   def test_daemon_is_a_known_config_key_with_boolean_coercion
     assert_includes Mutineer::KNOWN_KEYS, "daemon"

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -45,6 +45,12 @@ class CliTest < Minitest::Test
     assert_includes err, "--jobs requires a positive integer"
   end
 
+  def test_non_numeric_threshold_exits_two
+    _, err, status = mutineer("run", "x.rb", "--threshold", "abc")
+    assert_equal 2, status.exitstatus
+    assert_includes err, "--threshold requires a number"
+  end
+
   def test_unknown_format_exits_two
     _, err, status = mutineer("run", "x.rb", "--format", "csv")
     assert_equal 2, status.exitstatus

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -54,6 +54,13 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_from_file_rejects_non_numeric_threshold
+    with_config("threshold: abc\n") do |path|
+      err = assert_raises(Mutineer::ConfigError) { Config.from_file(path) }
+      assert_match(/threshold must be a number/, err.message)
+    end
+  end
+
   def test_from_file_warns_on_unknown_operator_and_drops_it
     with_config("operators: [arithmetic, bogus]\n") do |path|
       _, err = capture_io { @hash = Config.from_file(path) }

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -167,15 +167,18 @@ class ConfigTest < Minitest::Test
     assert_equal true, Config.resolve({ verbose: true }, {}, Set.new).verbose
   end
 
-  # #12: --rails defaults to serial (one DB, parallel forks deadlock); explicit wins.
+  # In-process --rails shares one DB; always serial. --daemon may use --jobs N.
   def test_resolve_rails_defaults_jobs_to_one
     assert_equal 1, Config.resolve({ rails: true }, {}, Set.new).jobs
   end
 
-  def test_resolve_rails_respects_explicit_jobs
-    # jobs is normalized to an Integer later in CLI.validate!; resolve keeps it as
-    # given. The point: --rails does NOT clobber an explicit --jobs.
+  def test_resolve_rails_forces_serial_even_when_jobs_explicit
     cfg = Config.resolve({ rails: true, jobs: "4" }, {}, Set[:jobs])
+    assert_equal 1, cfg.jobs
+  end
+
+  def test_resolve_rails_daemon_keeps_explicit_jobs
+    cfg = Config.resolve({ rails: true, daemon: true, jobs: "4" }, {}, Set[:jobs])
     assert_equal "4", cfg.jobs
   end
 

--- a/test/external_backend_test.rb
+++ b/test/external_backend_test.rb
@@ -48,6 +48,13 @@ class ExternalBackendTest < Minitest::Test
     assert_predicate result, :killed?
   end
 
+  def test_signal_death_is_error_not_killed
+    # Self-SIGKILL: exitstatus is nil; must not inflate kill rate.
+    result = Backend.run("#{RUBY} -e 'Process.kill(:KILL, Process.pid)' %{files}", ["x"], timeout: 30)
+    assert_predicate result, :error?
+    refute_predicate result, :killed?
+  end
+
   def test_timeout_is_timeout_and_fast
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     _out, err = capture_io do

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -75,8 +75,24 @@ class ReporterTest < Minitest::Test
     assert_equal 0, r.exit_code(threshold: 80.0) # 80.0 >= 80.0
   end
 
-  def test_exit_code_nil_score_skips_gate
+  def test_exit_code_nil_score_pure_no_coverage_skips_gate
     assert_equal 0, reporter([Mutineer::Result.no_coverage]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_all_ignored_skips_gate
+    assert_equal 0, reporter([Mutineer::Result.ignored]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_with_errors_fails_gate
+    assert_equal 1, reporter([Mutineer::Result.error("boom")]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_with_timeouts_fails_gate
+    assert_equal 1, reporter([Mutineer::Result.timeout]).exit_code(threshold: 80.0)
+  end
+
+  def test_exit_code_nil_score_with_uncapturable_fails_gate
+    assert_equal 1, reporter([Mutineer::Result.uncapturable]).exit_code(threshold: 80.0)
   end
 
   # --- rendering / streams ---

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -167,6 +167,17 @@ class ReporterTest < Minitest::Test
     assert_includes err.string, "threshold check is skipped"
   end
 
+  def test_na_score_broken_harness_fails_gate_with_clear_message
+    out = StringIO.new
+    err = StringIO.new
+    reporter([Mutineer::Result.error("boom"), Mutineer::Result.timeout])
+      .report(out: out, err: err, threshold: 80.0)
+    assert_includes out.string, "Mutation score: N/A"
+    assert_includes err.string, "threshold gate fails"
+    assert_includes out.string, "FAILED: no covered mutants"
+    refute_includes err.string, "threshold check is skipped"
+  end
+
   # #11: a multi-source run shows a per-source line per file (sorted by path).
   def test_per_source_block_for_multiple_sources
     other = Mutineer::Subject.new(file: "other.rb", namespace: ["O"], name: :m,

--- a/test/runner_daemon_test.rb
+++ b/test/runner_daemon_test.rb
@@ -64,6 +64,7 @@ class RunnerDaemonTest < Minitest::Test
         assert_nil map
       end
       assert_match(/daemon coverage map unavailable/, err)
+      assert_match(/DaemonBootError/, err)
     end
   end
 end

--- a/test/runner_daemon_test.rb
+++ b/test/runner_daemon_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "minitest/mock"
 require "mutineer/config"
 require "mutineer/runner"
 require "mutineer/cli"
@@ -44,13 +45,25 @@ class RunnerDaemonTest < Minitest::Test
     assert_operator aggregate.killed_count, :>, 0, "weak suite still kills some"
   end
 
-  # #26/U8: the daemon backend has no coverage narrowing yet, so its score is not
-  # comparable to an in-process run — the CLI must disclose that on every --daemon
-  # run, symmetric to the --test-command "upper bound" disclosure (cli.rb:465).
-  def test_cli_discloses_lower_bound_on_daemon_run
+  # Successful daemon coverage narrowing: no stale "lower bound / no narrowing"
+  # caveat. Fallback-only warnings live on Runner.daemon_coverage_map (nil map).
+  def test_cli_does_not_claim_stale_daemon_lower_bound_when_map_ok
     _out, err = capture_io do
       assert_raises(SystemExit) { Mutineer::CLI.execute(config_for("order_test.rb")) }
     end
-    assert_match(/--daemon score is a lower bound/, err)
+    refute_match(/--daemon score is a lower bound/, err)
+    refute_match(/no coverage narrowing yet/, err)
+    refute_match(/daemon coverage map unavailable/, err)
+  end
+
+  def test_daemon_coverage_map_warns_when_unavailable
+    cfg = config_for("order_test.rb")
+    Mutineer::DaemonClient.stub(:new, ->(*) { raise Mutineer::DaemonBootError, "boom" }) do
+      _out, err = capture_io do
+        map = Mutineer::Runner.daemon_coverage_map(cfg, cfg.tests.map { |t| File.expand_path(t, cfg.project_root) })
+        assert_nil map
+      end
+      assert_match(/daemon coverage map unavailable/, err)
+    end
   end
 end


### PR DESCRIPTION
## What
`--fail-fast` forces `jobs = 1` on the in-process path (same as daemon) so the survivor set is deterministic.

Closes #54

**Stack:** base = #52-53 branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->