### PR TITLE
fix: --test-command uses app Ruby under version managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`--test-command` under version managers** — scrub Mutineer's rbenv/asdf
+  version bins and bundler/gem env from the child so the suite can resolve the
+  app's Ruby via shims / `.ruby-version`. Smoke check prints a targeted hint on
+  `Bundler::RubyVersionMismatch` instead of only blaming DB/migrations. Docs
+  cover a wrapper recipe for stubborn setups (#32).
+
 ## [0.11.1] - 2026-07-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -151,11 +151,41 @@ RAILS_ENV=test mutineer run app/models/order.rb \
 
 - **`%{files}`** is required; it expands to the `--test` paths as separate
   arguments (a path with a space stays one argument — there is no shell).
-- **Environment** is inherited by the subprocess, so set it on the Mutineer
-  command (e.g. the leading `RAILS_ENV=test` above). Don't put `KEY=val` inside
-  `--test-command`.
+- **Environment:** suite-relevant vars (e.g. `RAILS_ENV`) set on the Mutineer
+  command are inherited. Bundler/gem injection from Mutineer's Ruby is scrubbed,
+  and version-manager **version bins** (e.g. `~/.rbenv/versions/3.4.x/bin`) are
+  removed from `PATH` so shims / `.ruby-version` can select the app's Ruby.
+  Don't put `KEY=val` prefixes *inside* `--test-command` (no shell; that would
+  be treated as the program name).
 
-Tradeoffs (Phase 1) — this path is correct but not free:
+#### Under a version manager (rbenv / asdf / chruby)
+
+If the smoke check still reports a **Ruby version mismatch** (suite ran under
+Mutineer's 3.4.x but the Gemfile wants e.g. 3.1.6), wrap the suite so it always
+re-selects the app's Ruby. Example rbenv wrapper (`bin/mutineer-test` in the app):
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+unset GEM_HOME GEM_PATH RUBYLIB RUBYOPT BUNDLE_GEMFILE BUNDLE_BIN_PATH BUNDLER_VERSION
+export RBENV_VERSION="$(cat .ruby-version 2>/dev/null || true)"
+export RAILS_ENV="${RAILS_ENV:-test}"
+export PATH="${HOME}/.rbenv/shims:${PATH}"
+exec bundle exec rails test "$@"
+```
+
+```sh
+# Mutineer on 3.4+; suite on the app's Ruby via the wrapper
+mutineer run app/models/order.rb \
+  --test test/models/order_test.rb \
+  --test-command "bin/mutineer-test %{files}"
+```
+
+Mutineer also surfaces a targeted smoke-check message when Bundler prints
+`RubyVersionMismatch`, instead of only blaming DB/migrations.
+
+Tradeoffs — this path is correct but not free:
 
 - **Slower:** your app re-boots for every mutant (no shared boot yet).
 - **No coverage narrowing:** every mutant runs the *full* `--test` set, so the

--- a/README.md
+++ b/README.md
@@ -151,18 +151,23 @@ RAILS_ENV=test mutineer run app/models/order.rb \
 
 - **`%{files}`** is required; it expands to the `--test` paths as separate
   arguments (a path with a space stays one argument — there is no shell).
-- **Environment:** suite-relevant vars (e.g. `RAILS_ENV`) set on the Mutineer
-  command are inherited. Bundler/gem injection from Mutineer's Ruby is scrubbed,
-  and version-manager **version bins** (e.g. `~/.rbenv/versions/3.4.x/bin`) are
-  removed from `PATH` so shims / `.ruby-version` can select the app's Ruby.
-  Don't put `KEY=val` prefixes *inside* `--test-command` (no shell; that would
-  be treated as the program name).
+- **Environment:** vars like `RAILS_ENV` / `DATABASE_URL` set on the Mutineer
+  command are inherited. Mutineer **unsets** `BUNDLE_*`, `GEM_*`, `RUBY*`,
+  `RBENV_VERSION`, `ASDF_RUBY_VERSION`, and `RBENV_DIR` in the child (so
+  Mutineer's own Ruby cannot pin the suite), and drops version-manager
+  **version bins** (e.g. `~/.rbenv/versions/3.4.x/bin`) from `PATH`, then
+  prepends rbenv/asdf shims when a pin was scrubbed. Do not rely on
+  `RBENV_VERSION=…` on the Mutineer command for the suite; use `.ruby-version`
+  or a wrapper. Don't put `KEY=val` prefixes *inside* `--test-command` (no shell;
+  that would be treated as the program name).
 
 #### Under a version manager (rbenv / asdf / chruby)
 
-If the smoke check still reports a **Ruby version mismatch** (suite ran under
-Mutineer's 3.4.x but the Gemfile wants e.g. 3.1.6), wrap the suite so it always
-re-selects the app's Ruby. Example rbenv wrapper (`bin/mutineer-test` in the app):
+Automatic scrub targets **rbenv** and **asdf** (shims + version bins). **chruby**
+has no shims: Mutineer still strips `…/rubies/…/bin` so it cannot leave Mutineer's
+Ruby pinned, but you need a wrapper that sources chruby and selects the app
+version. If the smoke check still reports a **Ruby version mismatch**, wrap the
+suite. Example rbenv wrapper (`bin/mutineer-test` in the app):
 
 ```sh
 #!/usr/bin/env bash

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -49,8 +49,8 @@ module Mutineer
         --rails              Sugar for --boot config/environment --strategy redefine
         --test-command CMD   Run the target suite in the app's own runtime as a
                              subprocess (for apps on Ruby < 3.4). CMD must contain
-                             %{files} (expands to the --test paths). Env is inherited,
-                             e.g. RAILS_ENV=test mutineer run ... --test-command "..."
+                             %{files}. Scrubs Mutineer Ruby PATH pins; set RAILS_ENV
+                             on the mutineer command (not as KEY=val inside CMD)
         --daemon             Boot the app ONCE in a persistent daemon and fork per
                              mutant, with per-worker DB isolation so --jobs N is safe
                              under Rails (needs --rails/--boot; not with --test-command)

--- a/lib/mutineer/external_backend.rb
+++ b/lib/mutineer/external_backend.rb
@@ -34,15 +34,22 @@ module Mutineer
     POLL = 0.02
 
     # PATH entries that pin a concrete Ruby under a version manager (ahead of
-    # shims). Matched as full path components so normal bins are left alone.
+    # shims). Optional trailing slash; normal bins are left alone.
     VERSION_BIN_PATH = %r{
       (?:
         /\.rbenv/versions/[^/]+/bin
         |/\.asdf/installs/ruby/[^/]+/bin
         |/\.rubies/[^/]+/bin
         |/rubies/[^/]+/bin
-      )\z
+      )/?\z
     }x
+
+    # Env keys Process.spawn must unset (nil value) so Mutineer's Ruby/bundler
+    # context does not leak. Spawn merges env onto the parent; omitting a key
+    # does NOT clear it.
+    CLEAR_ENV_KEYS = %w[
+      BUNDLER_VERSION RBENV_VERSION ASDF_RUBY_VERSION RBENV_DIR
+    ].freeze
 
     # Turn a command template into an argv array (no shell → no eval, no
     # injection). The `%{files}` token expands IN PLACE to N separate argv
@@ -56,23 +63,43 @@ module Mutineer
       Shellwords.split(command).flat_map { |tok| tok == "%{files}" ? files : [tok] }
     end
 
-    # Environment for the test-command child. Strips Mutineer/bundler injection and
-    # version-manager PATH pins so the app's Ruby (via shims + `.ruby-version`) can
-    # win. Keeps other vars (e.g. `RAILS_ENV`, `DATABASE_URL`) so setting them on
-    # the Mutineer command still reaches the suite.
+    # Environment delta for the test-command child. Process.spawn merges this
+    # onto the parent env: set a key to +nil+ to unset it. Scrubs Mutineer/bundler
+    # injection and version-manager PATH pins so shims / `.ruby-version` can win.
+    # Keeps other vars (e.g. `RAILS_ENV`) so setting them on the Mutineer command
+    # still reaches the suite.
     #
     # @api private
-    # @return [Hash{String => String}] env for Process.spawn.
+    # @return [Hash{String => String, nil}] env for Process.spawn.
     def self.child_env
-      env = ENV.to_h.reject do |k, _|
-        k.start_with?("BUNDLE_", "RUBY", "GEM_") ||
-          %w[BUNDLER_VERSION RBENV_VERSION ASDF_RUBY_VERSION RBENV_DIR].include?(k)
+      env = {}
+      cleared_pin = false
+      ENV.each_key do |k|
+        next unless clear_env_key?(k)
+
+        env[k] = nil
+        cleared_pin = true
       end
-      path = env["PATH"].to_s.split(File::PATH_SEPARATOR)
-      path.reject! { |p| p.match?(VERSION_BIN_PATH) }
-      shims = version_manager_shim_dirs
-      env["PATH"] = (shims + path).uniq.join(File::PATH_SEPARATOR)
+      path = ENV["PATH"].to_s.split(File::PATH_SEPARATOR)
+      kept = path.reject { |p| p.match?(VERSION_BIN_PATH) }
+      scrubbed_bin = kept.size != path.size
+      # Only reorder PATH when we scrubbed a pin; otherwise leave the user's PATH alone.
+      path = if cleared_pin || scrubbed_bin
+               (version_manager_shim_dirs + kept).uniq
+             else
+               kept
+             end
+      env["PATH"] = path.join(File::PATH_SEPARATOR)
       env
+    end
+
+    # True when the key must be unset in the child (bundler/gem/version-manager).
+    #
+    # @api private
+    # @param key [String] environment variable name.
+    # @return [Boolean]
+    def self.clear_env_key?(key)
+      key.start_with?("BUNDLE_", "RUBY", "GEM_") || CLEAR_ENV_KEYS.include?(key)
     end
 
     # Existing shim directories for rbenv / asdf (chruby uses PATH without shims).
@@ -152,7 +179,8 @@ module Mutineer
     # @api private
     # @return [String]
     def self.generic_env_hint
-      "the environment looks broken (check DB, RAILS_ENV, migrations), not the tests weak"
+      "the unmutated suite is not green (failing tests, or a broken environment: " \
+        "DB, RAILS_ENV, migrations) — fix that before scoring"
     end
 
     # Targeted hint when Bundler reports a RubyVersionMismatch (common under
@@ -170,8 +198,10 @@ module Mutineer
       parts = +"Detected a Ruby version mismatch"
       parts << ": the test command ran under #{ran}" if ran
       parts << " but the app expects #{want}" if want
-      parts << ". Under a version manager (rbenv/asdf/chruby), Mutineer's Ruby can sit " \
-               "ahead on PATH — wrap the command so it re-selects the app's Ruby " \
+      parts << ". Mutineer already scrubbed version-manager bins and RBENV_VERSION/" \
+               "ASDF_RUBY_VERSION from the child env; the suite still picked the wrong " \
+               "Ruby. Use a wrapper that re-selects the app Ruby and ensure " \
+               ".ruby-version / .tool-versions is present " \
                "(see README: Apps on Ruby < 3.4 → Under a version manager)"
       parts
     end

--- a/lib/mutineer/external_backend.rb
+++ b/lib/mutineer/external_backend.rb
@@ -10,17 +10,21 @@ module Mutineer
   # tests. The CLI maps this to a runtime error (exit 1), not a usage error.
   class SmokeCheckError < StandardError; end
 
-  # #27 (U3): the external execution backend. Runs the user's `--test-command` as a
-  # subprocess in the app's OWN runtime (whatever Ruby its bundle resolves to), so
-  # mutineer (Ruby >= 3.4) can mutation-test apps pinned to an older Ruby.
+  # External execution backend. Runs the user's `--test-command` as a subprocess
+  # in the app's own runtime (whatever Ruby its bundle resolves to), so mutineer
+  # (Ruby ≥ 3.4) can mutation-test apps pinned to an older Ruby.
   #
   # This is deliberately NOT a `TestRunners` framework adapter: those return an
   # Integer 0/1 from inside a fork and are dispatched by framework name. This is a
   # whole backend — it spawns a process, enforces a wall-clock timeout, and maps
-  # the exit status to a Result. The mapping is the SAME direction as in-process
+  # the exit status to a Result. The mapping is the same direction as in-process
   # (suite passes => survived, suite fails => killed) but coarser: it cannot tell an
   # infrastructure error from a genuine kill, so the smoke check (below) guards the
-  # persistent case and the score is disclosed as an upper bound (KTD-3/KTD-6).
+  # persistent case and the score is disclosed as an upper bound.
+  #
+  # Child environment: bundler/gem env injected by Mutineer's Ruby is stripped, and
+  # version-manager concrete version bins (e.g. `~/.rbenv/versions/3.4.9/bin`) are
+  # removed from PATH so shims / `.ruby-version` can select the app's Ruby (#32).
   module ExternalBackend
     # Generous ceiling for the one-off smoke/calibration run (a cold app boot plus
     # the full suite). The per-mutant timeout is derived from how long this took.
@@ -28,6 +32,17 @@ module Mutineer
     # Poll interval for the deadline wait loop. Independent of Isolation's loop —
     # this backend waits on an external process TREE, not an in-process fork.
     POLL = 0.02
+
+    # PATH entries that pin a concrete Ruby under a version manager (ahead of
+    # shims). Matched as full path components so normal bins are left alone.
+    VERSION_BIN_PATH = %r{
+      (?:
+        /\.rbenv/versions/[^/]+/bin
+        |/\.asdf/installs/ruby/[^/]+/bin
+        |/\.rubies/[^/]+/bin
+        |/rubies/[^/]+/bin
+      )\z
+    }x
 
     # Turn a command template into an argv array (no shell → no eval, no
     # injection). The `%{files}` token expands IN PLACE to N separate argv
@@ -41,10 +56,43 @@ module Mutineer
       Shellwords.split(command).flat_map { |tok| tok == "%{files}" ? files : [tok] }
     end
 
+    # Environment for the test-command child. Strips Mutineer/bundler injection and
+    # version-manager PATH pins so the app's Ruby (via shims + `.ruby-version`) can
+    # win. Keeps other vars (e.g. `RAILS_ENV`, `DATABASE_URL`) so setting them on
+    # the Mutineer command still reaches the suite.
+    #
+    # @api private
+    # @return [Hash{String => String}] env for Process.spawn.
+    def self.child_env
+      env = ENV.to_h.reject do |k, _|
+        k.start_with?("BUNDLE_", "RUBY", "GEM_") ||
+          %w[BUNDLER_VERSION RBENV_VERSION ASDF_RUBY_VERSION RBENV_DIR].include?(k)
+      end
+      path = env["PATH"].to_s.split(File::PATH_SEPARATOR)
+      path.reject! { |p| p.match?(VERSION_BIN_PATH) }
+      shims = version_manager_shim_dirs
+      env["PATH"] = (shims + path).uniq.join(File::PATH_SEPARATOR)
+      env
+    end
+
+    # Existing shim directories for rbenv / asdf (chruby uses PATH without shims).
+    #
+    # @api private
+    # @return [Array<String>] absolute shim paths that exist.
+    def self.version_manager_shim_dirs
+      home = ENV["HOME"]
+      return [] if home.nil? || home.empty?
+
+      [
+        File.join(home, ".rbenv", "shims"),
+        File.join(home, ".asdf", "shims")
+      ].select { |d| File.directory?(d) }
+    end
+
     # Runs the command for ONE mutant against whatever is currently on disk (the
     # caller has already swapped the mutant in via FileSwap). Maps the outcome to a
-    # Result. Env is inherited by the subprocess, so `RAILS_ENV=test mutineer …`
-    # reaches the child with no parsing here.
+    # Result. Uses {child_env} so version-manager PATH pins from Mutineer's Ruby do
+    # not force the suite onto the wrong interpreter.
     #
     # @param command [String] the --test-command template.
     # @param files [Array<String>] test file paths.
@@ -93,10 +141,39 @@ module Mutineer
         else                      "exited #{code}"
         end
       detail = output.empty? ? "" : "\n--- last output ---\n#{tail(output)}"
+      hint = ruby_version_mismatch_hint(output)
       raise SmokeCheckError,
-            "the test command #{reason} against the UNMUTATED source — the " \
-            "environment looks broken (check DB, RAILS_ENV, migrations), not the " \
-            "tests weak.#{detail}"
+            "the test command #{reason} against the UNMUTATED source — " \
+            "#{hint || generic_env_hint}.#{detail}"
+    end
+
+    # Generic smoke-failure framing when no Ruby-version mismatch is detected.
+    #
+    # @api private
+    # @return [String]
+    def self.generic_env_hint
+      "the environment looks broken (check DB, RAILS_ENV, migrations), not the tests weak"
+    end
+
+    # Targeted hint when Bundler reports a RubyVersionMismatch (common under
+    # rbenv/asdf/chruby when Mutineer's version bin sits ahead of shims on PATH).
+    #
+    # @api private
+    # @param output [String] captured child stdout+stderr.
+    # @return [String, nil] hint text, or nil when not a version mismatch.
+    def self.ruby_version_mismatch_hint(output)
+      return nil if output.nil? || output.empty?
+      return nil unless output.match?(/RubyVersionMismatch|Your Ruby version is .* but your Gemfile specified/i)
+
+      ran = output[/Your Ruby version is ([0-9.]+)/i, 1]
+      want = output[/Gemfile specified ([0-9.]+)/i, 1]
+      parts = +"Detected a Ruby version mismatch"
+      parts << ": the test command ran under #{ran}" if ran
+      parts << " but the app expects #{want}" if want
+      parts << ". Under a version manager (rbenv/asdf/chruby), Mutineer's Ruby can sit " \
+               "ahead on PATH — wrap the command so it re-selects the app's Ruby " \
+               "(see README: Apps on Ruby < 3.4 → Under a version manager)"
+      parts
     end
 
     # Spawns the command to a captured combined-output tempfile, enforces a
@@ -122,7 +199,8 @@ module Mutineer
       # explicit [program, argv0] form guarantees the no-shell exec path even for a
       # degenerate single-element argv (Process.spawn(*argv) would route a lone
       # metachar-bearing string through /bin/sh, breaking the argv-only invariant).
-      pid = Process.spawn([argv.first, argv.first], *argv[1..], out: out, err: %i[child out], pgroup: true)
+      pid = Process.spawn(child_env, [argv.first, argv.first], *argv[1..],
+                          out: out, err: %i[child out], pgroup: true)
       kind, code = wait_with_timeout(pid, timeout)
       elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
       out.rewind

--- a/test/external_backend_test.rb
+++ b/test/external_backend_test.rb
@@ -66,7 +66,8 @@ class ExternalBackendTest < Minitest::Test
     assert_match(/exceeded 1s/, err)
   end
 
-  # Env is inherited by the subprocess — no KEY=val parsing on our side.
+  # Non-bundler env is still inherited (RAILS_ENV-style vars set on the Mutineer
+  # command). Bundler/gem injection is scrubbed separately (#32).
   def test_env_is_inherited
     ENV["MUTINEER_ENV_PROBE"] = "1"
     with_script(%(exit(ENV["MUTINEER_ENV_PROBE"] == "1" ? 0 : 1))) do |path|
@@ -74,6 +75,33 @@ class ExternalBackendTest < Minitest::Test
     end
   ensure
     ENV.delete("MUTINEER_ENV_PROBE")
+  end
+
+  def test_child_env_strips_gem_and_bundler_injection
+    ENV["GEM_HOME"] = "/tmp/mutineer-fake-gems"
+    ENV["BUNDLE_GEMFILE"] = "/tmp/MutineerGemfile"
+    ENV["RBENV_VERSION"] = "3.4.9"
+    env = Backend.child_env
+    assert_nil env["GEM_HOME"]
+    assert_nil env["BUNDLE_GEMFILE"]
+    assert_nil env["RBENV_VERSION"]
+  ensure
+    ENV.delete("GEM_HOME")
+    ENV.delete("BUNDLE_GEMFILE")
+    ENV.delete("RBENV_VERSION")
+  end
+
+  def test_child_env_scrubs_rbenv_version_bin_from_path
+    version_bin = File.expand_path("~/.rbenv/versions/3.4.9/bin")
+    original_path = ENV["PATH"]
+    ENV["PATH"] = "#{version_bin}:/usr/bin:/bin"
+    ENV["RBENV_VERSION"] = "3.4.9"
+    env = Backend.child_env
+    refute_includes env["PATH"].split(File::PATH_SEPARATOR), version_bin
+    assert_includes env["PATH"], "/usr/bin"
+  ensure
+    ENV["PATH"] = original_path if original_path
+    ENV.delete("RBENV_VERSION")
   end
 
   # --verbose surfaces the child's captured output; default run stays quiet on a kill.
@@ -101,6 +129,21 @@ class ExternalBackendTest < Minitest::Test
       end
       assert_match(/environment looks broken/, err.message)
       assert_match(/db down/, err.message)
+    end
+  end
+
+  def test_smoke_check_ruby_version_mismatch_gives_targeted_hint
+    msg = "Bundler::RubyVersionMismatch: Your Ruby version is 3.4.9, " \
+          "but your Gemfile specified 3.1.6"
+    with_script(%(STDERR.puts #{msg.inspect}\nexit 1\n)) do |path|
+      err = assert_raises(Mutineer::SmokeCheckError) do
+        Backend.smoke_check!("#{RUBY} #{path} %{files}", ["x"], timeout: 30)
+      end
+      assert_match(/Ruby version mismatch/, err.message)
+      assert_match(/3\.4\.9/, err.message)
+      assert_match(/3\.1\.6/, err.message)
+      assert_match(/version manager/, err.message)
+      refute_match(/check DB, RAILS_ENV/, err.message)
     end
   end
 end

--- a/test/external_backend_test.rb
+++ b/test/external_backend_test.rb
@@ -77,31 +77,59 @@ class ExternalBackendTest < Minitest::Test
     ENV.delete("MUTINEER_ENV_PROBE")
   end
 
+  # child_env must pass nil (not omit keys) so Process.spawn unsets them.
   def test_child_env_strips_gem_and_bundler_injection
+    prior = {
+      "GEM_HOME" => ENV["GEM_HOME"],
+      "BUNDLE_GEMFILE" => ENV["BUNDLE_GEMFILE"],
+      "RBENV_VERSION" => ENV["RBENV_VERSION"]
+    }
     ENV["GEM_HOME"] = "/tmp/mutineer-fake-gems"
     ENV["BUNDLE_GEMFILE"] = "/tmp/MutineerGemfile"
     ENV["RBENV_VERSION"] = "3.4.9"
     env = Backend.child_env
+    assert env.key?("GEM_HOME")
     assert_nil env["GEM_HOME"]
     assert_nil env["BUNDLE_GEMFILE"]
     assert_nil env["RBENV_VERSION"]
   ensure
-    ENV.delete("GEM_HOME")
-    ENV.delete("BUNDLE_GEMFILE")
-    ENV.delete("RBENV_VERSION")
+    prior.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
   end
 
+  # Concrete version bins (optional trailing slash) leave PATH so shims can win.
   def test_child_env_scrubs_rbenv_version_bin_from_path
     version_bin = File.expand_path("~/.rbenv/versions/3.4.9/bin")
-    original_path = ENV["PATH"]
-    ENV["PATH"] = "#{version_bin}:/usr/bin:/bin"
+    prior_path = ENV["PATH"]
+    prior_rbenv = ENV["RBENV_VERSION"]
+    ENV["PATH"] = "#{version_bin}:#{version_bin}/:/usr/bin:/bin"
     ENV["RBENV_VERSION"] = "3.4.9"
     env = Backend.child_env
-    refute_includes env["PATH"].split(File::PATH_SEPARATOR), version_bin
+    parts = env["PATH"].split(File::PATH_SEPARATOR)
+    refute_includes parts, version_bin
+    refute_includes parts, "#{version_bin}/"
     assert_includes env["PATH"], "/usr/bin"
   ensure
-    ENV["PATH"] = original_path if original_path
-    ENV.delete("RBENV_VERSION")
+    ENV["PATH"] = prior_path if prior_path
+    prior_rbenv.nil? ? ENV.delete("RBENV_VERSION") : ENV["RBENV_VERSION"] = prior_rbenv
+  end
+
+  # Spawn merges env; nil must clear a leaked RBENV_VERSION in the child.
+  def test_spawn_unsets_rbenv_version_via_nil
+    prior = ENV["RBENV_VERSION"]
+    ENV["RBENV_VERSION"] = "3.4.9"
+    out = Tempfile.create("mutineer_env")
+    pid = Process.spawn(Backend.child_env, RUBY, "-e",
+                        "print ENV['RBENV_VERSION'].inspect",
+                        out: out, err: out)
+    Process.wait(pid)
+    out.rewind
+    assert_equal "nil", out.read.strip
+  ensure
+    prior.nil? ? ENV.delete("RBENV_VERSION") : ENV["RBENV_VERSION"] = prior
+    if out
+      out.close
+      File.unlink(out.path) rescue nil # rubocop:disable Style/RescueModifier
+    end
   end
 
   # --verbose surfaces the child's captured output; default run stays quiet on a kill.
@@ -127,7 +155,7 @@ class ExternalBackendTest < Minitest::Test
       err = assert_raises(Mutineer::SmokeCheckError) do
         Backend.smoke_check!("#{RUBY} #{path} %{files}", ["x"], timeout: 30)
       end
-      assert_match(/environment looks broken/, err.message)
+      assert_match(/unmutated suite is not green/, err.message)
       assert_match(/db down/, err.message)
     end
   end

--- a/test/runner_external_test.rb
+++ b/test/runner_external_test.rb
@@ -68,7 +68,7 @@ class RunnerExternalTest < Minitest::Test
       out, err, status = mutineer("run", "calculator.rb", "--test", "calculator_strong_test.rb",
                                   "--test-command", "#{RUBY} -e exit(1) %{files}", chdir: proj)
       assert_equal 1, status.exitstatus
-      assert_match(/environment looks broken/, err)
+      assert_match(/unmutated suite is not green/, err)
       refute_match(/mutation score/i, out)
     end
   end


### PR DESCRIPTION
## What
`--test-command` no longer forces the suite onto Mutineer's Ruby when rbenv/asdf/chruby put a concrete version bin ahead of shims on `PATH`. Smoke check names Ruby version mismatches instead of only blaming DB/migrations.

## Why
`--test-command` is the path for apps on Ruby < 3.4. Under a version manager the inherited PATH made Bundler raise `RubyVersionMismatch`, and the error pointed users at the wrong cause.

## How
- `ExternalBackend.child_env`: strip `BUNDLE_*` / `RUBY*` / `GEM_*` / `RBENV_VERSION` / `ASDF_RUBY_VERSION`, drop version-manager version bins from PATH, prepend existing shims dirs
- Pass that env to `Process.spawn`
- Detect mismatch text in smoke check and print a targeted hint
- README: version-manager section + wrapper example

Closes #32

## Test plan
- [x] `bundle exec rake test` (408 runs)
- [x] `bundle exec rake yard:strict`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->