### PR TITLE
chore: comment diet on orchestration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- **Comment diet on orchestration files** — present-tense YARD contracts; drop
+  ticket/phase/KTD history tags from runner, CLI, daemon pair, coverage map,
+  reporter, result, and related modules. Safety and score invariants kept (#57).
+
 ## [0.11.2] - 2026-07-24
 
 ### Fixed

--- a/lib/mutineer/baseline.rb
+++ b/lib/mutineer/baseline.rb
@@ -4,29 +4,27 @@ require "json"
 require_relative "config" # for Mutineer::ConfigError
 
 module Mutineer
-  # #13: CI baseline/delta gating. A baseline is literally a prior
-  # `mutineer run --format json` document (KTD-1) — no bespoke format to
-  # version.
-  # We diff the current run against it by the #10 stable survivor id (KTD-2):
-  # a NEW survivor (id present now, absent in the baseline) OR a score drop is
-  # a regression the CLI turns into exit 1. Pure data — stdlib `json` only, no
-  # fork, no Rails — so it's testable in isolation from a canned JSON + a hand-
-  # built AggregateResult.
+  # CI baseline/delta gating. A baseline is a prior
+  # `mutineer run --format json` document (no bespoke format to version).
+  # Diff the current run against it by the stable survivor id: a NEW survivor
+  # (id present now, absent in the baseline) OR a score drop is a regression the
+  # CLI turns into exit 1. Pure data, stdlib `json` only, no fork, no Rails, so
+  # it is testable in isolation from a canned JSON + a hand-built AggregateResult.
   class Baseline
     # The verdict of diffing a current run against the baseline.
-    #   new_survivors   — current Result objects whose stable id is absent from
+    #   new_survivors   - current Result objects whose stable id is absent from
     #                     the baseline (the regressions to name).
-    #   fixed_survivors — baseline survivor hashes absent from the current run
+    #   fixed_survivors - baseline survivor hashes absent from the current run
     #                     (informational, never gates).
-    #   score_drop      — current score < baseline score - epsilon. nil on
+    #   score_drop      - current score < baseline score - epsilon. nil on
     #                     either side skips the check (see #diff).
-    #   regressed       — any new survivors OR a score drop.
+    #   regressed       - any new survivors OR a score drop.
     Delta = Data.define(:new_survivors, :fixed_survivors,
                         :score_before, :score_after, :score_drop, :regressed)
 
-    # Load a prior --format json run. Raises ConfigError (NOT exit — R8: a data
-    # class must never kill the host) on a missing/unreadable file, unparseable
-    # JSON, or a doc that isn't a baseline shape, so the CLI maps it to exit 2
+    # Load a prior --format json run. Raises ConfigError (NOT exit: a data class
+    # must never kill the host) on a missing/unreadable file, unparseable JSON,
+    # or a doc that is not a baseline shape, so the CLI maps it to exit 2
     # (usage) like every other bad-path flag.
     #
     # @param path [String] baseline JSON file path.
@@ -72,7 +70,7 @@ module Mutineer
 
       current_score = aggregate.mutation_score
       # nil-score discipline (mirrors Reporter#exit_code): a score absent on
-      # either side can't be compared — skip the drop check, keep the new-
+      # either side cannot be compared. Skip the drop check, keep the new-
       # survivor check.
       score_drop = !@score.nil? && !current_score.nil? &&
                    current_score < @score - epsilon

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -18,7 +18,7 @@ module Mutineer
   # Command-line entry point. `start` is the single public method called by
   # bin/mutineer; it parses argv, acts, and exits with a pinned code.
   #
-  # Exit codes (taxonomy consistent across M1–M5):
+  # Exit codes:
   #   0  success / requested output (--version, --help, score >= threshold)
   #   1  survivors below threshold, or a runtime error
   #   2  usage / flag error (unknown subcommand, invalid flag, unknown operator,
@@ -78,7 +78,7 @@ module Mutineer
     # @return [void]
     def self.start(argv)
       opts = {}            # symbol => value, the CLI-provided Config fields
-      explicit = Set.new   # precedence keys the user typed (KTD3)
+      explicit = Set.new   # precedence keys the user typed
       show_operators = false
 
       parser = OptionParser.new do |o|
@@ -116,15 +116,15 @@ module Mutineer
         o.on("--debug") { opts[:verbose] = true } # alias of --verbose
         o.on("--format FORMAT") { |v| opts[:format] = v }
         o.on("--output FILE") { |v| opts[:output] = v }
-        # #13: --baseline is also a .mutineer.yml key, so mark it explicit when
-        # typed (CLI wins over the file). --baseline-epsilon is CLI-only.
+        # --baseline is also a .mutineer.yml key, so mark it explicit when typed
+        # (CLI wins over the file). --baseline-epsilon is CLI-only.
         o.on("--baseline FILE") { |v| opts[:baseline] = v; explicit << :baseline }
         o.on("--baseline-epsilon FLOAT") { |v| opts[:baseline_epsilon] = v.to_f }
-        # #27: run the target suite as a subprocess in the app's OWN runtime so
+        # Run the target suite as a subprocess in the app's OWN runtime so
         # mutineer (Ruby >= 3.4) can mutation-test apps pinned to an older Ruby.
         o.on("--test-command CMD") { |v| opts[:test_command] = v; explicit << :test_command }
-        # #26/#27 Phase 2: boot the app ONCE in a persistent daemon and fork per
-        # mutant, with per-worker DB isolation so --jobs N is safe under Rails.
+        # Boot the app ONCE in a persistent daemon and fork per mutant, with
+        # per-worker DB isolation so --jobs N is safe under Rails.
         o.on("--daemon") { opts[:daemon] = true; explicit << :daemon }
       end
 
@@ -150,7 +150,7 @@ module Mutineer
         file_hash = file_path ? Config.from_file(file_path) : {}
         config = Config.resolve(opts, file_hash, explicit)
       rescue Mutineer::ConfigError => e
-        # R8: the lib layer raises instead of killing the host; the CLI maps a
+        # The lib layer raises instead of killing the host; the CLI maps a
         # config (usage) error to exit 2.
         warn "mutineer: #{e.message}"
         exit 2
@@ -158,7 +158,7 @@ module Mutineer
 
       case argv.first
       when "run"
-        # #11: a directory source expands to its **/*.rb files; literal files pass
+        # A directory source expands to its **/*.rb files; literal files pass
         # through. Test inference (when --test is omitted) happens in validate!.
         config.sources = Pairing.expand_sources(argv[1..], project_root: config.project_root)
         run(config, explicit)
@@ -197,7 +197,7 @@ module Mutineer
       warn "mutineer: #{e.message}"
       exit 2
     rescue SystemCallError => e
-      # R5: a missing/unreadable path reaches here as Errno::ENOENT etc. — a plain
+      # A missing/unreadable path reaches here as Errno::ENOENT etc. A plain
       # message and usage exit, never a raw backtrace.
       warn "mutineer: #{e.message}"
       exit 2
@@ -210,15 +210,14 @@ module Mutineer
       warn "mutineer: error reading: #{e.message}"
       exit 1
     rescue Mutineer::SmokeCheckError => e
-      # #27: the unmutated suite isn't green under --test-command — a broken
+      # The unmutated suite is not green under --test-command: a broken
       # environment, not weak tests. Runtime error (exit 1), not usage (exit 2).
       warn "mutineer: #{e.message}"
       exit 1
     end
 
-    # Flag validation: every flag/usage failure exits 2 (C7), consistent with the
-    # taxonomy above — CI can tell "mistyped flag" from "tests too weak."
-    # Validates the run configuration.
+    # Flag validation: every flag/usage failure exits 2, consistent with the
+    # taxonomy above. CI can tell "mistyped flag" from "tests too weak."
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
@@ -279,13 +278,12 @@ module Mutineer
       validate_paths!(config)
     end
 
-    # #27: --test-command runs the target suite in the app's own runtime. Validate
-    # its shape up front (usage errors → exit 2) and force serial execution: each
+    # --test-command runs the target suite in the app's own runtime. Validate its
+    # shape up front (usage errors → exit 2) and force serial execution: each
     # subprocess boots the app and opens its own fixture transaction against the
-    # same DB, so --jobs > 1 would corrupt results (the #12 fixture-contention
-    # hazard). Unlike --rails, this path has NO per-worker DB isolation to opt into,
-    # so an explicit --jobs N is forced to 1 rather than honored (KTD-5).
-    # Validates the --test-command configuration.
+    # same DB, so --jobs > 1 would corrupt results (fixture-contention hazard).
+    # Unlike --rails, this path has NO per-worker DB isolation to opt into, so an
+    # explicit --jobs N is forced to 1 rather than honored.
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
@@ -347,7 +345,6 @@ module Mutineer
 
     # --since needs a real git repo and a resolvable ref; either failure is a
     # usage error (exit 2) so CI sees "bad invocation," not "tests too weak."
-    # Validates the --since ref.
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
@@ -370,10 +367,9 @@ module Mutineer
       exit 2
     end
 
-    # R5: validate path existence up front so a typo is a clean usage error (exit
-    # 2), not an Errno::ENOENT backtrace from deep in the run. Flag checks run
-    # first so a bad flag still reports the flag, not the missing file.
-    # Validates source and test paths.
+    # Validate path existence up front so a typo is a clean usage error (exit 2),
+    # not an Errno::ENOENT backtrace from deep in the run. Flag checks run first
+    # so a bad flag still reports the flag, not the missing file.
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
@@ -387,14 +383,13 @@ module Mutineer
       exit 2
     end
 
-    # #11: auto-pair sources to tests by path convention when no --test was given
-    # (explicit --test wins — R5). Each source with an inferred test on disk joins
-    # the run; a source with none is dropped with a one-line stderr warning (R3)
-    # and the run continues with the rest. If every source is dropped: in boot mode
-    # the dedicated --boot/--rails-requires-test check reports it; otherwise exit 2
+    # Auto-pair sources to tests by path convention when no --test was given
+    # (explicit --test wins). Each source with an inferred test on disk joins the
+    # run; a source with none is dropped with a one-line stderr warning and the
+    # run continues with the rest. If every source is dropped: in boot mode the
+    # dedicated --boot/--rails-requires-test check reports it; otherwise exit 2
     # with a usage message. The framework is re-detected from the inferred set
     # unless it was set explicitly (a spec-only project loads/reports as rspec).
-    # Auto-pairs sources and tests when --test is absent.
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
@@ -421,11 +416,10 @@ module Mutineer
       exit 2
     end
 
-    # #13: a missing/unreadable/unparseable baseline is a usage error (exit 2),
+    # A missing/unreadable/unparseable baseline is a usage error (exit 2),
     # mirroring --output/--since preflight, so CI sees "bad invocation," not a
     # backtrace mid-run. Validating up front = attempting the load (it raises
     # ConfigError/SystemCallError; the actual diff reloads in execute).
-    # Preflights a baseline file.
     #
     # @api private
     # @param path [String] baseline file path.
@@ -464,7 +458,7 @@ module Mutineer
       aggregate, source_map = Runner.execute(config)
       reporter = Reporter.new(aggregate, source_map)
 
-      # #13: diff the current run against the baseline (preflighted above) by the
+      # Diff the current run against the baseline (preflighted above) by the
       # stable survivor id. The delta is rendered inline (human section / additive
       # json block) and gates exit independently of --threshold.
       delta = (Baseline.load(config.baseline).diff(aggregate, epsilon: config.baseline_epsilon) if config.baseline)
@@ -476,28 +470,27 @@ module Mutineer
       # is not comparable to an in-process run: no coverage narrowing (uncovered
       # mutants count as survivors), and an infra failure is scored as a kill
       # (upper bound). Daemon coverage fallback warnings are emitted from the runner
-      # only when the map is unavailable — not on every --daemon run.
+      # only when the map is unavailable, not on every --daemon run.
       if config.test_command
         warn "[mutineer] --test-command score is an upper bound, not comparable to an " \
              "in-process run: no coverage narrowing (uncovered mutants count as survivors) " \
              "and an infra failure is scored as a kill."
       end
 
-      # Nudge toward the opt-in tier-2 operators (human report only — never
+      # Nudge toward the opt-in tier-2 operators (human report only: never
       # pollute JSON output).
       if !%w[json html].include?(config.format) && (hint = tier2_hint(config.operators))
         puts hint
       end
 
-      # #13/KTD-4: --baseline and --threshold are independent gates OR'd together.
+      # --baseline and --threshold are independent gates OR'd together.
       # `max` of two 0/1 codes is the OR; usage (2) is handled earlier and wins.
       baseline_exit = delta&.regressed ? 1 : 0
       exit [reporter.exit_code(threshold: config.threshold), baseline_exit].max
     end
 
     # The tier-2 operators not in the active set, as a one-line hint (or nil when
-    # they're all already enabled). `active` nil means the default (Tier-1) set.
-    # Builds a Tier-2 operator hint.
+    # they are all already enabled). `active` nil means the default (Tier-1) set.
     #
     # @param active [Array<String>, nil] active operator names.
     # @return [String, nil] hint text or nil.

--- a/lib/mutineer/config.rb
+++ b/lib/mutineer/config.rb
@@ -4,20 +4,20 @@ require "etc"
 require "yaml"
 
 module Mutineer
-  # Raised by the config layer instead of calling exit/abort — a data class must
-  # never kill the host process (R8). The CLI rescues this and maps it to exit 2.
+  # Raised by the config layer instead of calling exit/abort. A data class must
+  # never kill the host process. The CLI rescues this and maps it to exit 2.
   class ConfigError < StandardError; end
 
   # Plain run configuration, populated by the CLI (or directly by the
   # integration test). `operators` nil means "all default operators";
   # `threshold` 0.0 means the CI gate is off (spec §10).
   #
-  # M5 adds: jobs (parallel workers), format (human|json), output (report file),
-  # strategy (reload|redefine), require_paths (extra files to load). Config loading and
-  # the CLI > file > default precedence merge live here (KTD3/KTD4).
+  # Also holds: jobs (parallel workers), format (human|json), output (report
+  # file), strategy (reload|redefine), require_paths (extra files to load).
+  # Config loading and the CLI > file > default precedence merge live here.
   #
-  # Boot mode adds: boot (a file to require ONCE in the parent so the app env —
-  # e.g. Rails — is booted before forking; sources are then NOT manually required)
+  # Boot mode adds: boot (a file to require ONCE in the parent so the app env,
+  # e.g. Rails, is booted before forking; sources are then NOT manually required)
   # and rails (sugar: defaults boot to config/environment and strategy to redefine,
   # and reconnects ActiveRecord per fork).
   Config = Struct.new(
@@ -25,7 +25,7 @@ module Mutineer
     :cache_dir, :project_root, :load_paths,
     :jobs, :format, :output, :strategy, :require_paths,
     :boot, :rails, :since, :framework, :verbose, :ignore,
-    # :daemon is user-facing as of U8 (--daemon flag + KNOWN_KEYS + boolean coerce).
+    # :daemon is user-facing (--daemon flag + KNOWN_KEYS + boolean coerce).
     # :daemon_timeout stays programmatic (set by tests/Runner; no flag yet).
     :baseline, :baseline_epsilon, :fail_fast, :test_command,
     :daemon, :daemon_timeout,
@@ -33,7 +33,7 @@ module Mutineer
   ) do
     # Config file name.
     CONFIG_FILE = ".mutineer.yml"
-    # Keys accepted in .mutineer.yml (R7). `require` maps to the :require_paths field.
+    # Keys accepted in .mutineer.yml. `require` maps to the :require_paths field.
     KNOWN_KEYS = %w[operators jobs threshold only require boot rails since framework verbose ignore baseline fail_fast test_command daemon].freeze
 
     def initialize(**kwargs)
@@ -59,8 +59,8 @@ module Mutineer
 
     # Walk from `start` toward `home`, returning the first .mutineer.yml path found
     # or nil. Checks `home` itself, then stops; if `start` is above `home`
-    # (e.g. /tmp), the walk continues to the filesystem root (KTD4). Pure
-    # discovery — reads no file content.
+    # (e.g. /tmp), the walk continues to the filesystem root. Pure discovery;
+    # reads no file content.
     def self.find_file(start = Dir.pwd, home = File.expand_path("~"))
       dir = File.expand_path(start)
       loop do
@@ -77,9 +77,9 @@ module Mutineer
     end
 
     # Parse a .mutineer.yml into a symbol-keyed hash of recognized keys. Unknown
-    # keys / unknown operator names emit a one-line stderr warning and are ignored
-    # (R7). A YAML syntax error raises ConfigError (R7a/R8) — never a silent
-    # fallback to defaults, and never an exit from the lib layer.
+    # keys / unknown operator names emit a one-line stderr warning and are ignored.
+    # A YAML syntax error raises ConfigError: never a silent fallback to defaults,
+    # and never an exit from the lib layer.
     def self.from_file(path)
       raw = YAML.safe_load(File.read(path)) || {}
       name = File.basename(path)
@@ -103,7 +103,7 @@ module Mutineer
       raise ConfigError, "#{File.basename(path)} parse error: #{e.message}"
     end
 
-    # Apply precedence (KTD3): start from the CLI-provided values, then fill in a
+    # Apply precedence: start from the CLI-provided values, then fill in a
     # config-file value only for keys the user did NOT type on the command line.
     # `explicit` is a Set of field symbols the CLI saw with a value; a Set (not
     # nil-sentinels) is used because some valid values are zero/false.
@@ -114,7 +114,7 @@ module Mutineer
 
       # --rails sugar: boot config/environment. Prefer redefine only for the
       # in-process path (daemon is whole-file reload only). In-process --rails
-      # shares one test database — force serial unless --daemon.
+      # shares one test database, so force serial unless --daemon.
       if config.rails
         config.boot ||= "config/environment"
         unless config.daemon || explicit.include?(:strategy)
@@ -138,7 +138,6 @@ module Mutineer
 
     # Pick rspec when a MAJORITY of the given test files end with _spec.rb;
     # otherwise minitest. Empty/ambiguous -> minitest (the safe default).
-    # Detects the test framework from the file list.
     #
     # @param tests [Array<String>] test file paths.
     # @return [String] `"rspec"` or `"minitest"`.
@@ -187,10 +186,9 @@ module Mutineer
       end
     end
 
-    # Drop (with a warning) operator names the registry doesn't know (R7).
+    # Drop (with a warning) operator names the registry does not know.
     # Referenced lazily so config.rb carries no load-order dependency on the
     # registry; by the time a config is parsed at runtime, it is loaded.
-    # Filters out unknown operator names.
     #
     # @api private
     # @param names [Array<String>] operator names.

--- a/lib/mutineer/coverage_map.rb
+++ b/lib/mutineer/coverage_map.rb
@@ -19,7 +19,8 @@ module Mutineer
   # Keys are "file:line" strings (relative to project_root) everywhere, in
   # memory and on disk, so load/save needs no key transformation.
   class CoverageMap
-    DEFAULT_CAPTURE_TIMEOUT = 120 # seconds, per coverage subprocess
+    # Seconds per coverage subprocess before the parent kills it.
+    DEFAULT_CAPTURE_TIMEOUT = 120
 
     attr_reader :project_root, :failed_test_files, :phase_a_ran, :map
 

--- a/lib/mutineer/coverage_map.rb
+++ b/lib/mutineer/coverage_map.rb
@@ -12,21 +12,22 @@ require_relative "test_runners"
 
 module Mutineer
   # Maps `(source_file, line) -> [test_files]` so each mutant runs only against
-  # the tests that actually exercise its line. Built once (Phase A), then queried
-  # per mutant (Phase B via #tests_for). Persisted to .mutineer/coverage.json with
-  # a content-based digest that rebuilds the map whenever any tracked file changes.
+  # the tests that actually exercise its line. Built once, then queried per
+  # mutant via #tests_for. Persisted to .mutineer/coverage.json with a
+  # content-based digest that rebuilds the map whenever any tracked file changes.
   #
-  # Keys are "file:line" strings (relative to project_root) everywhere — in
-  # memory and on disk — so load/save needs no key transformation (KTD4).
+  # Keys are "file:line" strings (relative to project_root) everywhere, in
+  # memory and on disk, so load/save needs no key transformation.
   class CoverageMap
-    DEFAULT_CAPTURE_TIMEOUT = 120 # seconds, per coverage subprocess (R3)
+    DEFAULT_CAPTURE_TIMEOUT = 120 # seconds, per coverage subprocess
 
     attr_reader :project_root, :failed_test_files, :phase_a_ran, :map
 
-    # Build a QUERY-ONLY map from data captured elsewhere (the daemon builds the map
-    # app-side and ships `map` + `failed_test_files` over IPC; the tool reconstructs it
-    # here for per-mutant selection). Skips the capture machinery entirely — only the
-    # three fields #tests_for / #method_uncapturable? read are set (U7).
+    # Build a QUERY-ONLY map from data captured elsewhere (the daemon builds the
+    # map app-side and ships `map` + `failed_test_files` over IPC; the tool
+    # reconstructs it here for per-mutant selection). Skips the capture machinery
+    # entirely: only the three fields #tests_for / #method_uncapturable? read are
+    # set.
     #
     # @param map [Hash] the "file:line" => [test_files] map.
     # @param failed_test_files [Array<String>] test files whose capture failed.
@@ -58,14 +59,14 @@ module Mutineer
       @phase_a_ran  = false
     end
 
-    # Phase A entry point (standalone): load the cached map when the content
-    # digest matches, otherwise rebuild from subprocesses and overwrite the cache.
+    # Standalone entry: load the cached map when the content digest matches,
+    # otherwise rebuild from subprocesses and overwrite the cache.
     def build_or_load
       warn_external_sources
       cached_or { run_phase_a }
     end
 
-    # Boot-mode Phase A: Coverage is already running in the parent (started before
+    # Boot-mode build: Coverage is already running in the parent (started before
     # the app booted, so booted source lines are instrumented). A clean `ruby`
     # subprocess has no booted env, so per-test coverage is captured by FORKING
     # the booted parent instead. Inverts into the same map #tests_for reads, and
@@ -76,25 +77,25 @@ module Mutineer
       cached_or { run_phase_a_via_fork(after_fork: after_fork) }
     end
 
-    # Phase B lookup: the test files that cover `file:line`, or [] when none do.
-    # ponytail: per-file granularity; upgrade to per-method when throughput
-    # warrants (requires Minitest method isolation + finer Coverage tracking).
+    # Lookup: the test files that cover `file:line`, or [] when none do.
+    # Per-file granularity; upgrade to per-method when throughput warrants
+    # (requires Minitest method isolation + finer Coverage tracking).
     def tests_for(file, line)
       @map["#{relativize(file)}:#{line}"] || []
     end
 
-    # #9: is this source file's empty coverage the result of an *errored* capture
-    # rather than a genuine coverage gap? True iff (KTD-2) some capture failed this
-    # run AND this file got zero coverage from any successful capture AND a failed
+    # Is this source file's empty coverage the result of an *errored* capture
+    # rather than a genuine coverage gap? True iff some capture failed this run
+    # AND this file got zero coverage from any successful capture AND a failed
     # test file maps to it by the standard _test/_spec naming convention. Derived
-    # purely from already-persisted state (@map keys + @failed_test_files); no rerun,
-    # no new cached field, no digest change.
+    # purely from already-persisted state (@map keys + @failed_test_files); no
+    # rerun, no new cached field, no digest change.
     #
-    # ponytail: file-level, convention-based attribution. A line covered only by a
-    # failed test in an otherwise-covered file stays no_coverage (condition 2), and
-    # a source with no naming-convention test match is never tainted. Upgrade path:
-    # persist per-file coverage per successful run and diff against the failed set,
-    # or record test->source targets explicitly. Not needed for the #8/#9 cases.
+    # File-level, convention-based attribution. A line covered only by a failed
+    # test in an otherwise-covered file stays no_coverage (condition 2), and a
+    # source with no naming-convention test match is never tainted. Upgrade path:
+    # persist per-file coverage per successful run and diff against the failed
+    # set, or record test->source targets explicitly.
     def uncapturable_source?(file)
       return false if @failed_test_files.empty?
 
@@ -104,14 +105,14 @@ module Mutineer
       failed_test_targets.include?(File.basename(rel, ".rb"))
     end
 
-    # #25: per-METHOD taint. A mutant on a line whose enclosing method got zero
+    # Per-method taint. A mutant on a line whose enclosing method got zero
     # successful coverage, in a file a failed sibling test targets, is
-    # :uncapturable (the capture that would have covered it errored) — NOT a
+    # :uncapturable (the capture that would have covered it errored), NOT a
     # genuine gap. A method with any covered line means its uncovered lines are a
     # real :no_coverage. A failed capture emits no coverage, so per-line intent is
-    # unknowable; method-range + successful coverage is the finest derivable signal.
-    # Fully-failed files behave exactly as uncapturable_source? did (every method
-    # range has zero coverage), so #8/#9/#19 behavior is unchanged.
+    # unknowable; method-range + successful coverage is the finest derivable
+    # signal. Fully-failed files behave exactly as uncapturable_source? did
+    # (every method range has zero coverage).
     #
     # @param file [String] source file path.
     # @param line_range [Range] 1-based enclosing-method line range.
@@ -155,7 +156,7 @@ module Mutineer
       self
     end
 
-    # Runs standalone Phase A coverage capture.
+    # Runs standalone coverage capture.
     #
     # @api private
     def run_phase_a
@@ -171,11 +172,11 @@ module Mutineer
       end
     end
 
-    # Boot-mode Phase A. For each test file, fork the booted parent; the child
+    # Boot-mode capture. For each test file, fork the booted parent; the child
     # resets its Coverage delta, runs that ONE test, and marshals back the raw
     # per-source coverage counts. record() inverts them exactly as the subprocess
-    # path does. ponytail: serial fork (one test at a time) — boot apps fork
-    # cheaply via COW and per-test isolation matters more than throughput here.
+    # path does. Serial fork (one test at a time): boot apps fork cheaply via COW
+    # and per-test isolation matters more than throughput here.
     def run_phase_a_via_fork(after_fork:)
       @phase_a_ran = true
       @map = {}
@@ -183,9 +184,9 @@ module Mutineer
       abs_sources = abs_source_paths
 
       @test_paths.each do |test_path|
-        # Tri-state payload (KTD-1): Hash = coverage, String = error diagnostic
-        # from the child, nil = pipe gone / empty.
-        # ponytail/#9: this String diagnostic is what #9 turns into an :uncapturable status.
+        # Tri-state payload: Hash = coverage, String = error diagnostic from the
+        # child, nil = pipe gone / empty. The String diagnostic is what becomes
+        # an :uncapturable status.
         case (coverage = fork_capture(absolute(test_path), abs_sources, after_fork))
         when Hash   then record(coverage, test_path)
         when String
@@ -201,7 +202,7 @@ module Mutineer
     # fork + Marshal-over-pipe + hard-exit! discipline as WorkerPool/Isolation.
     def fork_capture(abs_test, abs_sources, after_fork)
       rd, wr = IO.pipe
-      # #19: Marshal output is binary — an un-binmoded pipe can raise
+      # Marshal output is binary: an un-binmoded pipe can raise
       # Encoding::UndefinedConversionError on write, which the child's rescue then
       # swallows, losing the real error and yielding a bare "no result".
       rd.binmode
@@ -210,9 +211,9 @@ module Mutineer
         rd.close
         payload =
           begin
-            # Fork-safety hook: the in-process path reconnects AR; the daemon routes
-            # to its worker DB. Nil (non-Rails) = no-op. Injected so this file needs
-            # neither Runner (Prism) nor Rails.
+            # Fork-safety hook: the in-process path reconnects AR; the daemon
+            # routes to its worker DB. Nil (non-Rails) = no-op. Injected so this
+            # file needs neither Runner (Prism) nor Rails.
             after_fork&.call
             Coverage.result(clear: true, stop: false) # discard pre-test delta
             TestRunners.for(@framework).run([abs_test])
@@ -222,7 +223,7 @@ module Mutineer
                     .select { |f, _| abs_sources.include?(f) }
                     .transform_values { |v| v.is_a?(Hash) ? v[:lines] : v }
           rescue Exception => e # rubocop:disable Lint/RescueException
-            # KTD-1: stringify (an arbitrary Exception may not marshal); the parent
+            # Stringify (an arbitrary Exception may not marshal); the parent
             # surfaces this under --verbose. A String marshals safely over the pipe.
             "#{e.class}: #{e.message}#{e.backtrace&.first ? " @ #{e.backtrace.first}" : ''}"
           end
@@ -239,7 +240,7 @@ module Mutineer
       data = rd.read
       rd.close
       _, status = Process.waitpid2(pid)
-      # #19: an empty pipe means the child died before writing (e.g. a hard crash,
+      # An empty pipe means the child died before writing (e.g. a hard crash,
       # OOM, or a signal from the test's own subprocess handling). Report HOW it
       # died (exit status / signal) as a diagnostic string so --verbose has
       # something actionable instead of a silent "no result".
@@ -266,8 +267,8 @@ module Mutineer
 
     # Spawns a fresh `ruby` reading an inline script from stdin. A fork would
     # miss already-loaded app lines, so Coverage must start in a clean process
-    # before any source is loaded (KTD1/KTD2). Returns the parsed Coverage.result
-    # hash, or nil when the subprocess failed (logged + skipped per R6).
+    # before any source is loaded. Returns the parsed Coverage.result hash, or
+    # nil when the subprocess failed (logged + skipped).
     def capture(test_path)
       out = +""
       status = nil
@@ -275,8 +276,8 @@ module Mutineer
         stdin.write(subprocess_script(test_path))
         stdin.close
         reader = Thread.new { out << stdout.read }
-        # R3: bound the subprocess with a wall clock — a hanging test file must
-        # not wedge the whole run before any per-mutant timeout.
+        # Bound the subprocess with a wall clock: a hanging test file must not
+        # wedge the whole run before any per-mutant timeout.
         unless wait_thr.join(@capture_timeout)
           Process.kill(:KILL, wait_thr.pid) rescue nil # rubocop:disable Style/RescueModifier
           reader.kill
@@ -374,7 +375,7 @@ module Mutineer
       rel_test = relativize(test_path)
       coverage.each do |abs_file, data|
         rel = relativize(abs_file)
-        next if rel.start_with?("/") # outside project_root — not our source
+        next if rel.start_with?("/") # outside project_root: not our source
 
         counts = data.is_a?(Array) ? data : data["lines"]
         counts.each_with_index do |count, idx|
@@ -385,7 +386,7 @@ module Mutineer
       end
     end
 
-    # R4: digest each file's ROLE + relative path + content length + content, plus
+    # Digest each file's ROLE + relative path + content length + content, plus
     # the load_paths. Without role/path/length delimiters the digest collides
     # (("ab","c") == ("a","bc")) and is blind to source/test role swaps, silently
     # accepting a stale cached map.
@@ -426,7 +427,7 @@ module Mutineer
       end
     end
 
-    # R7: a configured source that resolves outside project_root would silently be
+    # A configured source that resolves outside project_root would silently be
     # dropped (its coverage relativizes to an absolute path). Warn instead.
     def warn_external_sources
       @source_paths.each do |p|
@@ -452,7 +453,7 @@ module Mutineer
 
       JSON.parse(File.read(cache_path))
     rescue JSON::ParserError
-      nil # corrupt cache — rebuild from scratch
+      nil # corrupt cache: rebuild from scratch
     end
 
     # Saves the coverage cache.

--- a/lib/mutineer/daemon_client.rb
+++ b/lib/mutineer/daemon_client.rb
@@ -4,19 +4,20 @@ require "json"
 require "open3"
 
 module Mutineer
-  # Raised when the daemon cannot be booted (bad boot path, app error, or it dies on
-  # the handshake). The CLI maps it to a runtime error.
+  # Raised when the daemon cannot be booted (bad boot path, app error, or it dies
+  # on the handshake). The CLI maps it to a runtime error.
   class DaemonBootError < StandardError; end
 
-  # #26/#27 Phase 2a — the TOOL-side handle for the app-side daemon.
+  # Tool-side handle for the app-side daemon.
   #
-  # Spawns `daemon_server.rb` UNDER THE APP'S BUNDLE/RUBY (cleaned env so the gem's
-  # bundler context never leaks; the daemon file is loaded by absolute path with
-  # `-r`, which bypasses the app bundle that has no mutineer), completes the ready
-  # handshake, then ships per-mutant payloads and reads structured verdicts. If the
-  # daemon dies mid-run it respawns (bounded) and marks the in-flight mutant `error`
-  # rather than corrupting the run. Reuses the cleaned-env spawn + stderr-drain proven
-  # in the spike driver and the spawn discipline of ExternalBackend.
+  # Spawns `daemon_server.rb` UNDER THE APP'S BUNDLE/RUBY (cleaned env so the
+  # gem's bundler context never leaks; the daemon file is loaded by absolute path
+  # with `-r`, which bypasses the app bundle that has no mutineer), completes the
+  # ready handshake, then ships per-mutant payloads and reads structured verdicts.
+  # If the daemon dies mid-run it respawns (bounded) and marks the in-flight
+  # mutant `error` rather than corrupting the run. Reuses the cleaned-env spawn
+  # and stderr-drain proven in the spike driver and the spawn discipline of
+  # ExternalBackend.
   class DaemonClient
     # Absolute path to the daemon entry, loaded app-side by `-r` (bypasses the bundle).
     DAEMON_PATH = File.expand_path("daemon_server.rb", __dir__)
@@ -49,14 +50,14 @@ module Mutineer
 
     # Run one mutant: ship the payload + covering tests, return the verdict string.
     # On a daemon crash (EOF/dead pipe) respawn (bounded) and return `"error"` for
-    # this mutant — never a wrong verdict, never a wedged run.
+    # this mutant. Never a wrong verdict, never a wedged run.
     #
     # @param id [Integer] request id (echoed back for ordering safety).
     # @param payload [Hash] {"code" => mutated ruby, "source_file" => path}.
     # @param tests [Array<String>] covering test file paths.
     # @param timeout [Numeric] per-mutant wall-clock timeout (seconds).
     # @param worker [Integer] worker slot; the daemon routes the fork to
-    #   `<db>-<worker>` (#26 isolation). Defaults to 0 (serial in U5).
+    #   `<db>-<worker>` for isolation. Defaults to 0 (serial).
     # @return [String] one of survived/killed/error/timeout.
     def request(id:, payload:, tests:, timeout:, worker: 0)
       # A crash can surface on the WRITE (daemon died idle between requests →
@@ -76,10 +77,11 @@ module Mutineer
       "error"
     end
 
-    # #26/U7: ask the daemon to build the coverage map app-side and return it.
-    # One-shot control message (no id). Returns `{"map"=>..., "failed_test_files"=>...}`
-    # (possibly with an `"error"`), or nil if the daemon vanished — the caller then
-    # falls back to running the full test set (no narrowing) rather than mis-scoring.
+    # Ask the daemon to build the coverage map app-side and return it. One-shot
+    # control message (no id). Returns `{"map"=>..., "failed_test_files"=>...}`
+    # (possibly with an `"error"`), or nil if the daemon vanished. The caller then
+    # falls back to running the full test set (no narrowing) rather than
+    # mis-scoring.
     #
     # @return [Hash, nil] the coverage payload, or nil on a dead pipe.
     def coverage
@@ -103,8 +105,8 @@ module Mutineer
 
     private
 
-    # Cleaned environment for the app bundle: strip the gem's bundler/Ruby context so
-    # `bundle exec` resolves the APP's Gemfile under the requested Ruby.
+    # Cleaned environment for the app bundle: strip the gem's bundler/Ruby context
+    # so `bundle exec` resolves the APP's Gemfile under the requested Ruby.
     def app_env
       env = ENV.to_h.reject { |k, _| k.start_with?("BUNDLE_", "RUBY", "GEM_") }
       env["BUNDLE_GEMFILE"] = @gemfile
@@ -118,17 +120,18 @@ module Mutineer
     # @return [void]
     # @raise [Mutineer::DaemonBootError] when the daemon fails to boot.
     def spawn_daemon
-      # Plain `bundle exec ruby` — NOT `rbenv exec`, which would break CI and any
-      # non-rbenv setup. When bundler/ruby are rbenv shims, the RBENV_VERSION carried
-      # in app_env still selects the app's Ruby; otherwise the active Ruby is used.
+      # Plain `bundle exec ruby`, NOT `rbenv exec`, which would break CI and any
+      # non-rbenv setup. When bundler/ruby are rbenv shims, the RBENV_VERSION
+      # carried in app_env still selects the app's Ruby; otherwise the active
+      # Ruby is used.
       @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
         app_env, "bundle", "exec", "ruby",
         "-r", DAEMON_PATH, "-e", "Mutineer::DaemonServer.run", chdir: @app_root
       )
       # Drain daemon stderr to the tool's stderr so child/boot errors are visible.
-      # Tracked (not fire-and-forget) so close_io can reclaim it on quit/respawn; the
-      # rescue swallows the benign EBADF/IOError raised when close_io closes the pipe
-      # out from under an in-flight copy_stream.
+      # Tracked (not fire-and-forget) so close_io can reclaim it on quit/respawn;
+      # the rescue swallows the benign EBADF/IOError raised when close_io closes
+      # the pipe out from under an in-flight copy_stream.
       @drain = Thread.new do # rubocop:disable ThreadSafety/NewThread
         IO.copy_stream(@stderr, @errio)
       rescue IOError, Errno::EBADF

--- a/lib/mutineer/daemon_server.rb
+++ b/lib/mutineer/daemon_server.rb
@@ -4,19 +4,20 @@ require "json"
 require "tempfile"
 
 module Mutineer
-  # #26/#27 Phase 2a — the app-side daemon (persistent worker).
+  # App-side daemon (persistent worker).
   #
   # Runs UNDER THE APP'S OWN BUNDLE/RUBY (the tool's DaemonClient spawns it via
   # `bundle exec ruby`). It boots the app ONCE, then serves per-mutant test-run
-  # requests over stdin/stdout as newline-delimited JSON. For each request it FORKS
-  # a child that loads the mutated source text the tool sent, runs the covering
-  # tests, and exits with a status the parent decodes into a verdict.
+  # requests over stdin/stdout as newline-delimited JSON. For each request it
+  # FORKS a child that loads the mutated source text the tool sent, runs the
+  # covering tests, and exits with a status the parent decodes into a verdict.
   #
-  # HARD CONSTRAINT (KTD-2/R4): this file must be loadable WITHOUT Prism or the rest
-  # of mutineer — the app's Ruby may be < 3.4 (no stdlib Prism) and its bundle has no
-  # mutineer. So it requires ONLY stdlib + the app's own boot file; it re-implements
-  # the fork/timeout/decode loop rather than requiring `isolation.rb` (which pulls in
-  # Prism). All parsing/mutation happened tool-side; the daemon only `load`s text.
+  # HARD CONSTRAINT: this file must be loadable WITHOUT Prism or the rest of
+  # mutineer. The app's Ruby may be < 3.4 (no stdlib Prism) and its bundle has no
+  # mutineer. So it requires ONLY stdlib + the app's own boot file; it
+  # re-implements the fork/timeout/decode loop rather than requiring
+  # `isolation.rb` (which pulls in Prism). All parsing/mutation happened
+  # tool-side; the daemon only `load`s text.
   #
   # Protocol (one JSON object per line, both directions):
   #   boot in  : {"cmd":"boot","project_root":"...","boot":"config/environment",
@@ -27,16 +28,18 @@ module Mutineer
   #   verdict  : {"id":N,"verdict":"survived"|"killed"|"error"|"timeout"}
   #   quit in  : {"cmd":"quit"}
   #
-  # Worker isolation (#26/U5): when the app is Rails, each fork is routed to its own
-  # database `<db>-<worker>` via {RailsWorkerDb} BEFORE any test loads, so concurrent
-  # workers can't clobber each other's transactional fixtures. `worker` defaults to 0
-  # (serial). SQLite this pass; Postgres provisioning is U10.
+  # Worker isolation: when the app is Rails, each fork is routed to its own
+  # database `<db>-<worker>` via {RailsWorkerDb} BEFORE any test loads, so
+  # concurrent workers cannot clobber each other's transactional fixtures.
+  # `worker` defaults to 0 (serial). SQLite this pass; Postgres provisioning is
+  # not yet implemented.
   #
-  # Verdict mapping (KTD-5, Phase-2a honest limit): child exit 0=survived (suite
-  # passed), 1=killed (suite failed), 2=error (child raised AROUND the test — load,
-  # boot, or worker-DB routing failure); parent-detected timeout. Tagging an in-TEST DB
-  # error (one fired inside a test body, vs at routing time) as `error` rather than
-  # `killed` is a U6 concern — only observable under the concurrent gate.
+  # Verdict mapping: child exit 0=survived (suite passed), 1=killed (suite
+  # failed), 2=error (child raised AROUND the test: load, boot, or worker-DB
+  # routing failure); parent-detected timeout. Tagging an in-test DB error (one
+  # fired inside a test body, vs at routing time) as `error` rather than
+  # `killed` is only observable under the concurrent gate and is not yet
+  # implemented.
   module DaemonServer
     # Poll interval (seconds) for the per-fork deadline wait loop.
     POLL = 0.02
@@ -65,16 +68,16 @@ module Mutineer
           begin
             req = JSON.parse(line)
           rescue JSON::ParserError => e
-            # A corrupt line has no id to address a reply to (and the client only ever
-            # sends valid JSON, so it can't be a pending request) — log and read on
-            # rather than write an unaddressable verdict onto the channel.
+            # A corrupt line has no id to address a reply to (and the client only
+            # ever sends valid JSON, so it cannot be a pending request). Log and
+            # read on rather than write an unaddressable verdict onto the channel.
             @errio.puts("[daemon] dropped unparseable line: #{e.message}")
             next
           end
           break if req["cmd"] == "quit"
 
-          # #26/U7: build the coverage map app-side and ship it to the tool, which
-          # then selects covering tests per mutant. One-shot control message.
+          # Build the coverage map app-side and ship it to the tool, which then
+          # selects covering tests per mutant. One-shot control message.
           if req["cmd"] == "coverage"
             output.puts(JSON.generate(build_coverage_map))
             output.flush
@@ -88,8 +91,8 @@ module Mutineer
 
       private
 
-      # BOOT ONCE. chdir + require the app's boot file so the whole app is loaded and
-      # inherited by every fork. Never requires mutineer.
+      # BOOT ONCE. chdir + require the app's boot file so the whole app is loaded
+      # and inherited by every fork. Never requires mutineer.
       def boot!(cfg)
         @cfg = cfg
         @framework = cfg.fetch("framework", "minitest")
@@ -97,30 +100,30 @@ module Mutineer
         Dir.chdir(cfg["project_root"]) if cfg["project_root"]
         ENV["RAILS_ENV"] ||= "test" if cfg["rails"]
         Array(cfg["load_paths"]).each { |d| $LOAD_PATH.unshift(File.expand_path(d)) }
-        # #26/U7: start Coverage BEFORE the app loads, so booted source lines are
-        # instrumented — the map build (build_via_fork) forks this booted parent.
+        # Start Coverage BEFORE the app loads, so booted source lines are
+        # instrumented. The map build (build_via_fork) forks this booted parent.
         if cfg["coverage"]
           require "coverage"
           Coverage.start(lines: true)
         end
         # Clear any mutant tempfile a prior SIGKILLed timeout child orphaned in a
-        # source dir BEFORE the app boots — Zeitwerk would otherwise choke on the
+        # source dir BEFORE the app boots. Zeitwerk would otherwise choke on the
         # tempfile's non-constant name during autoload setup.
         sweep_temps
         require File.expand_path(cfg["boot"]) if cfg["boot"]
         setup_worker_db(cfg) if cfg["rails"]
       rescue Exception => e # rubocop:disable Lint/RescueException
-        # Boot failed (bad boot path, app error) — tell the client and exit so it can
-        # surface a clean error rather than hang on the handshake.
+        # Boot failed (bad boot path, app error). Tell the client and exit so it
+        # can surface a clean error rather than hang on the handshake.
         @output.puts(JSON.generate("ready" => false, "error" => "#{e.class}: #{e.message}"))
         @output.flush
         exit!(1)
       end
 
-      # Load the per-worker DB adapter app-side (sibling gem file, by relative path so
-      # it bypasses the app bundle — like this daemon itself). No-op unless the app has
-      # ActiveRecord. Records the adapter + schema path so each fork can route to its
-      # own database (#26 isolation, U5). SQLite-only this pass; a non-SQLite config
+      # Load the per-worker DB adapter app-side (sibling gem file, by relative path
+      # so it bypasses the app bundle, like this daemon itself). No-op unless the
+      # app has ActiveRecord. Records the adapter + schema path so each fork can
+      # route to its own database. SQLite-only this pass; a non-SQLite config
       # raises in the fork and reads as `error`, never a mis-routed verdict.
       def setup_worker_db(cfg)
         require_relative "rails_worker_db"
@@ -134,11 +137,11 @@ module Mutineer
         @worker_db = nil
       end
 
-      # #26/U7: build the coverage map app-side (Coverage was started at boot) and
-      # return it as `{map, failed_test_files}` for the tool to select covering tests.
-      # Capture forks route to worker 0's DB (isolated, serial). On any failure return
-      # an empty map + an error string — the tool then falls back to the full test set
-      # rather than mis-scoring everything as no_coverage.
+      # Build the coverage map app-side (Coverage was started at boot) and return
+      # it as `{map, failed_test_files}` for the tool to select covering tests.
+      # Capture forks route to worker 0's DB (isolated, serial). On any failure
+      # return an empty map + an error string. The tool then falls back to the
+      # full test set rather than mis-scoring everything as no_coverage.
       def build_coverage_map
         require_relative "coverage_map"
         root = @cfg["project_root"] || Dir.pwd
@@ -153,9 +156,9 @@ module Mutineer
         { "map" => {}, "failed_test_files" => [], "error" => "#{e.class}: #{e.message}" }
       end
 
-      # Fork-safety hook for coverage capture: route each capture fork to worker 0's
-      # isolated DB (captures run serially, so one worker is enough). Nil when the app
-      # has no worker-DB adapter (non-Rails) — capture then runs as before.
+      # Fork-safety hook for coverage capture: route each capture fork to worker
+      # 0's isolated DB (captures run serially, so one worker is enough). Nil when
+      # the app has no worker-DB adapter (non-Rails). Capture then runs as before.
       def coverage_after_fork
         return nil unless @worker_db
 
@@ -190,16 +193,16 @@ module Mutineer
         verdict = wait_verdict(pid, timeout)
         # Mark ready only when the child finished cleanly after schema load
         # (killed/survived). Timeout can interrupt mid-load_schema; error is a
-        # routing failure — both leave the slot unready so the next fork reloads.
+        # routing failure. Both leave the slot unready so the next fork reloads.
         @schema_ready[worker] = true if schema_for_fork && %w[killed survived].include?(verdict)
-        # A SIGKILLed timeout child skipped its Tempfile unlink — sweep the orphan so
-        # it can't outlive the run or trip Zeitwerk on a later fork.
+        # A SIGKILLed timeout child skipped its Tempfile unlink. Sweep the orphan
+        # so it cannot outlive the run or trip Zeitwerk on a later fork.
         sweep_temps if verdict == "timeout"
         { "id" => req["id"], "verdict" => verdict }
       end
 
       # Remove orphaned mutant tempfiles from the source dirs (parent-side; the
-      # SIGKILL path can't run the child's ensure). Mirrors Runner.sweep_orphans.
+      # SIGKILL path cannot run the child's ensure). Mirrors Runner.sweep_orphans.
       def sweep_temps
         @source_dirs.to_a.each do |dir|
           Dir.glob(File.join(dir, "mutineer_daemon*.rb")).each do |f|
@@ -209,12 +212,12 @@ module Mutineer
       end
 
       # Single-waiter deadline loop (mirrors Isolation.run and
-      # ExternalBackend.wait_with_timeout, re-implemented here because Isolation pulls
-      # in Prism which is forbidden app-side). NOTE: this is the 3rd copy of the
-      # waitpid2(WNOHANG)+deadline+pgroup-SIGKILL+decode discipline — a fix to the
-      # kill/reap/decode logic must be applied to all three in lockstep. SIGKILL the
-      # child's process group past the deadline; a signalled child (nil exitstatus) is
-      # `error`.
+      # ExternalBackend.wait_with_timeout, re-implemented here because Isolation
+      # pulls in Prism which is forbidden app-side). NOTE: this is the 3rd copy of
+      # the waitpid2(WNOHANG)+deadline+pgroup-SIGKILL+decode discipline. A fix to
+      # the kill/reap/decode logic must be applied to all three in lockstep.
+      # SIGKILL the child's process group past the deadline; a signalled child
+      # (nil exitstatus) is `error`.
       def wait_verdict(pid, timeout)
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         loop do
@@ -242,14 +245,15 @@ module Mutineer
         end
       end
 
-      # Write the tool-built mutated text beside the real source and `load` it —
-      # reopening the mutated class/method in THIS child only. It goes in the source
-      # file's directory (like Isolation.apply_whole_file) so a `require_relative` in
-      # the mutated source resolves against its real neighbours — writing it to the
-      # tmpdir would LoadError on such files and score a spurious `error` that
-      # diverges from the in-process path. The Zeitwerk hazard (a stray `.rb` in an
-      # autoload dir) is handled by the boot/timeout `sweep_temps`, not by relocating
-      # the file. Same path for reload (whole file) and redefine (wrapped snippet).
+      # Write the tool-built mutated text beside the real source and `load` it,
+      # reopening the mutated class/method in THIS child only. It goes in the
+      # source file's directory (like Isolation.apply_whole_file) so a
+      # `require_relative` in the mutated source resolves against its real
+      # neighbours. Writing it to the tmpdir would LoadError on such files and
+      # score a spurious `error` that diverges from the in-process path. The
+      # Zeitwerk hazard (a stray `.rb` in an autoload dir) is handled by the
+      # boot/timeout `sweep_temps`, not by relocating the file. Same path for
+      # reload (whole file) and redefine (wrapped snippet).
       def apply_payload(payload)
         dir = File.dirname(File.expand_path(payload.fetch("source_file")))
         Tempfile.create(["mutineer_daemon", ".rb"], dir) do |f|
@@ -260,7 +264,7 @@ module Mutineer
       end
 
       # Load the covering test files and run them; 0 = all passed (survived),
-      # 1 = a failure/error (killed). Minitest only in 2a (rspec is a later unit).
+      # 1 = a failure/error (killed). Minitest only; rspec is not yet on this path.
       def run_tests(tests)
         raise "unsupported framework #{@framework.inspect}" unless @framework == "minitest"
 

--- a/lib/mutineer/file_swap.rb
+++ b/lib/mutineer/file_swap.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Mutineer
-  # Raised when a source file's backup already exists as FileSwap.with begins —
-  # a second mutineer run is racing on the same file (the backup path is shared
+  # Raised when a source file's backup already exists as FileSwap.with begins.
+  # A second mutineer run is racing on the same file (the backup path is shared
   # and unlocked). Aborting beats silently leaving the tree mutated.
   class ConcurrentRunError < StandardError
     def initialize(backup)
@@ -11,11 +11,11 @@ module Mutineer
     end
   end
 
-  # #27 (U2): apply one whole-file mutant to the REAL source path for the external
+  # Apply one whole-file mutant to the REAL source path for the external
   # (`--test-command`) backend, and guarantee the original is restored on every
-  # exit path. A separate `bundle exec` subprocess has its own VM and cannot see an
-  # in-process `load`, so the mutant must live on disk while its suite runs — which
-  # makes leaving the file mutated the one genuinely dangerous failure mode.
+  # exit path. A separate `bundle exec` subprocess has its own VM and cannot see
+  # an in-process `load`, so the mutant must live on disk while its suite runs,
+  # which makes leaving the file mutated the one genuinely dangerous failure mode.
   #
   # Defense in depth, mirroring the tempfile-orphan discipline
   # (`Runner.sweep_orphans`, `isolation.rb` tempfiles):
@@ -39,12 +39,13 @@ module Mutineer
     # @return [Object] the block's return value.
     def self.with(source_file, mutated)
       backup = source_file + BACKUP_SUFFIX
-      # A backup already on disk means either a prior hard-killed run (restore_orphans
-      # should have healed it at startup) or a SECOND mutineer run racing us on the
-      # same file. The backup path is shared and unlocked, so proceeding would let
-      # us capture the other run's mutant AS the "original" and permanently mutate
-      # the tree. Refuse loudly rather than silently corrupt — and do it BEFORE
-      # `created` is set, so the ensure below never touches a backup we don't own.
+      # A backup already on disk means either a prior hard-killed run
+      # (restore_orphans should have healed it at startup) or a SECOND mutineer
+      # run racing us on the same file. The backup path is shared and unlocked, so
+      # proceeding would let us capture the other run's mutant AS the "original"
+      # and permanently mutate the tree. Refuse loudly rather than silently
+      # corrupt, and do it BEFORE `created` is set, so the ensure below never
+      # touches a backup we don't own.
       raise ConcurrentRunError, backup if File.exist?(backup)
 
       original = File.binread(source_file)
@@ -74,11 +75,11 @@ module Mutineer
           backup_bytes = File.binread(backup)
           if !File.exist?(source_file)
             # A real user file that merely ends in our suffix, with no sibling to
-            # restore — leave it untouched (never create a file from it).
+            # restore. Leave it untouched (never create a file from it).
             next
           elsif File.binread(source_file) == backup_bytes
-            # Redundant backup (e.g. a crash between restore and unlink): nothing to
-            # heal, just clear the orphan so the next run doesn't see a false race.
+            # Redundant backup (e.g. a crash between restore and unlink): nothing
+            # to heal, just clear the orphan so the next run does not see a false race.
             File.unlink(backup)
           else
             File.binwrite(source_file, backup_bytes)

--- a/lib/mutineer/rails_worker_db.rb
+++ b/lib/mutineer/rails_worker_db.rb
@@ -1,33 +1,32 @@
 # frozen_string_literal: true
 
 module Mutineer
-  # #26/#27 Phase 2b (U5) — per-worker database isolation for the daemon path.
+  # Per-worker database isolation for the daemon path.
   #
-  # Loaded APP-SIDE by {DaemonServer} (a sibling gem file, pulled in by absolute path
-  # so it bypasses the app bundle — the same trick {DaemonClient} uses to run
-  # `daemon_server.rb` under a bundle that has no mutineer). It uses the app's OWN
-  # already-booted ActiveRecord and NEVER `require "active_record"` (R10/KTD-8): every
+  # Loaded APP-SIDE by {DaemonServer} (a sibling gem file, pulled in by absolute
+  # path so it bypasses the app bundle, the same trick {DaemonClient} uses to run
+  # `daemon_server.rb` under a bundle that has no mutineer). It uses the app's
+  # OWN already-booted ActiveRecord and NEVER `require "active_record"`: every
   # method that touches AR first confirms {available?}, so the daemon core stays
   # framework-agnostic and the gem keeps its zero-runtime-dependency promise.
   #
-  # Isolation model (KTD-7): each parallel worker gets its OWN database so concurrent
-  # forks can't clobber each other's transactional fixtures (the measured #26
-  # corruption). {after_fork} runs inside a freshly-forked child and points that
-  # child's connection at the worker's database BEFORE any test loads; transactional
-  # fixtures then repopulate that isolated database per test.
+  # Isolation model: each parallel worker gets its OWN database so concurrent
+  # forks cannot clobber each other's transactional fixtures. {after_fork} runs
+  # inside a freshly-forked child and points that child's connection at the
+  # worker's database BEFORE any test loads; transactional fixtures then
+  # repopulate that isolated database per test.
   #
-  # Scope: this pass ships the **SQLite** adapter (per-worker file, hermetic,
-  # spike-proven). Postgres per-worker DBs (`CREATE DATABASE <db>-<worker>`) are not
-  # implemented yet; a non-SQLite config raises a clear NotImplementedError rather
-  # than silently mis-routing.
+  # Scope: SQLite adapter only (per-worker file, hermetic). Postgres per-worker
+  # DBs (`CREATE DATABASE <db>-<worker>`) are not implemented yet; a non-SQLite
+  # config raises a clear NotImplementedError rather than silently mis-routing.
   #
-  # Honest limit (KTD-5): routing failures surface as `error` via {verify_connection!}.
-  # Re-raising an AR error that fires *inside a test body* past Minitest (so an in-test
-  # DB failure is `error`, not `killed`) is only observable under concurrent load and
-  # is deferred to U6 with the parallel gate — noted, not silently skipped.
+  # Routing failures surface as `error` via {verify_connection!}. Tagging an
+  # in-test DB failure as `error` (not `killed`) is only observable under
+  # concurrent load and is not yet implemented.
   module RailsWorkerDb
-    # True when the app has ActiveRecord loaded — the only condition under which any
-    # other method here may touch AR. Never triggers an autoload/require of AR itself.
+    # True when the app has ActiveRecord loaded. The only condition under which
+    # any other method here may touch AR. Never triggers an autoload/require of
+    # AR itself.
     #
     # @return [Boolean]
     def self.available?
@@ -35,8 +34,9 @@ module Mutineer
     end
 
     # Derive a per-worker database path from a base path by inserting `-<worker>`
-    # before the extension. Pure string transform (no AR) so it is unit-testable in
-    # the zero-dep suite. `storage/test.sqlite3`, worker 1 -> `storage/test-1.sqlite3`.
+    # before the extension. Pure string transform (no AR) so it is unit-testable
+    # in the zero-dep suite. `storage/test.sqlite3`, worker 1 ->
+    # `storage/test-1.sqlite3`.
     #
     # @param database [String] the base database path.
     # @param worker [Integer] the worker slot index (0..N-1).
@@ -47,9 +47,9 @@ module Mutineer
     end
 
     # Build the AR connection config for one worker by copying the app's current
-    # (default test) config and swapping in the per-worker database path. SQLite only
-    # this pass — a non-SQLite adapter raises so the SQLite-first scope fails loud
-    # instead of mis-routing (Postgres is U10).
+    # (default test) config and swapping in the per-worker database path. SQLite
+    # only this pass: a non-SQLite adapter raises so the SQLite-first scope fails
+    # loud instead of mis-routing.
     #
     # @param worker [Integer] the worker slot index.
     # @return [Hash] a symbol-keyed AR configuration hash for the worker database.
@@ -57,16 +57,15 @@ module Mutineer
     def self.worker_db_config(worker)
       hash    = ActiveRecord::Base.connection_db_config.configuration_hash
       adapter = hash[:adapter].to_s
-      # U10 seam: the config-SHAPING below (per_worker_config) is already
-      # adapter-general — it derives correct SQLite *and* Postgres worker-DB names.
-      # What's gated is runtime PROVISIONING: SQLite files are created on connect,
-      # but Postgres needs an explicit `CREATE DATABASE` per worker (U10). Until that
-      # lands, refuse non-SQLite loudly rather than route to a database that doesn't
-      # exist until Postgres worker creation is implemented.
+      # Config shaping (per_worker_config) is already adapter-general: it derives
+      # correct SQLite and Postgres worker-DB names. What is gated is runtime
+      # provisioning: SQLite files are created on connect, but Postgres needs an
+      # explicit `CREATE DATABASE` per worker. Until that lands, refuse non-SQLite
+      # loudly rather than route to a database that does not exist.
       unless adapter.start_with?("sqlite")
         raise NotImplementedError,
               "worker-DB isolation currently provisions SQLite only (got adapter #{adapter.inspect}); " \
-              "Postgres per-worker provisioning is U10 (#26/#35) — use a SQLite test DB, or drop --jobs."
+              "Postgres per-worker provisioning is not yet supported. Use a SQLite test DB, or drop --jobs."
       end
 
       per_worker_config(hash, worker)
@@ -74,10 +73,10 @@ module Mutineer
 
     # Pure config-shaping (no AR): given a connection config hash, return the
     # per-worker variant with its database swapped to the worker's own name.
-    # Adapter-general — SQLite (`storage/test.sqlite3` → `storage/test-<w>.sqlite3`)
-    # and Postgres (`myapp_test` → `myapp_test-<w>`, Rails `parallelize` naming) both
-    # fall out of {worker_database_path}. Extracted + unit-tested so the Postgres
-    # SHAPE is proven ready for U10 without a live database.
+    # Adapter-general: SQLite (`storage/test.sqlite3` -> `storage/test-<w>.sqlite3`)
+    # and Postgres (`myapp_test` -> `myapp_test-<w>`, Rails `parallelize` naming)
+    # both fall out of {worker_database_path}. Extracted and unit-tested so the
+    # Postgres shape is proven ready without a live database.
     #
     # @param config_hash [Hash] a connection config hash (symbol or string keys).
     # @param worker [Integer] the worker slot index.
@@ -94,11 +93,12 @@ module Mutineer
       hash.merge(database: worker_database_path(database, worker))
     end
 
-    # Child-side (after fork): route this process's ActiveRecord at the worker's own
-    # database and confirm it is reachable, so a routing failure reads as `error`
-    # (via the daemon's child rescue) rather than a false verdict. Loads the schema
-    # into the worker database when a schema path is given (idempotent — schema.rb
-    # runs with `force: true`), covering a fresh worker file.
+    # Child-side (after fork): route this process's ActiveRecord at the worker's
+    # own database and confirm it is reachable, so a routing failure reads as
+    # `error` (via the daemon's child rescue) rather than a false verdict. Loads
+    # the schema into the worker database when a schema path is given
+    # (idempotent: schema.rb runs with `force: true`), covering a fresh worker
+    # file.
     #
     # @param worker [Integer] the worker slot index.
     # @param schema_path [String, nil] absolute path to `db/schema.rb`, or nil to skip.
@@ -126,8 +126,9 @@ module Mutineer
       $stdout = original
     end
 
-    # Force a round-trip to the freshly-routed connection so a broken route fails HERE
-    # (→ `error`) instead of later masquerading as a test failure (→ false `killed`).
+    # Force a round-trip to the freshly-routed connection so a broken route fails
+    # HERE (→ `error`) instead of later masquerading as a test failure
+    # (→ false `killed`).
     #
     # @return [void]
     def self.verify_connection!

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -7,7 +7,7 @@ require_relative "mutation"
 
 module Mutineer
   # Renders an AggregateResult: the summary block, mutation score, and per-file
-  # survivor diffs. Stream discipline (R14): the report goes to `out` (stdout),
+  # survivor diffs. Stream discipline: the report goes to `out` (stdout),
   # diagnostics/warnings go to `err` (stderr), so `mutineer ... > report.txt`
   # captures only the report.
   #
@@ -19,7 +19,7 @@ module Mutineer
       @source_map = source_map
     end
 
-    # Single entry point (R20/R21). Branches on `format` ("human" | "json") and
+    # Single entry point. Branches on `format` ("human" | "json" | "html") and
     # routes the rendered report to `output` (a file, with a stderr confirmation)
     # or to `out`. Diagnostics always go to `err`.
     def report(out: $stdout, err: $stderr, threshold: 0.0, format: "human", output: nil, baseline: nil)
@@ -90,10 +90,9 @@ module Mutineer
 
     private
 
-    # Canonical machine-readable schema (KTD7). survivors/no_coverage are sorted
-    # by (file, line, operator) so output is byte-stable regardless of --jobs
-    # worker finish order (R22).
-    # Renders the JSON report.
+    # Canonical machine-readable schema. survivors/no_coverage are sorted by
+    # (file, line, operator) so output is byte-stable regardless of --jobs
+    # worker finish order.
     #
     # @api private
     # @param baseline [Mutineer::Baseline::Delta, nil] baseline delta.
@@ -101,7 +100,7 @@ module Mutineer
     def json_report(baseline = nil)
       killed = @agg.killed_count
       survived = @agg.survived_count
-      # C8: null (not 0.0) on an empty denominator, matching the nil-vs-0.0
+      # null (not 0.0) on an empty denominator, matching the nil-vs-0.0
       # discipline in AggregateResult; and the SAME rounding as the human report
       # (one run must not yield two scores by --format).
       score = @agg.mutation_score
@@ -121,31 +120,31 @@ module Mutineer
                        .sort_by { |h| [h[:file], h[:line], h[:operator]] },
         no_coverage: @agg.results.select(&:no_coverage?).map { |r| no_coverage_json(r) }
                          .sort_by { |h| [h[:file], h[:line]] },
-        # #9: same shape as no_coverage; additive key.
+        # Same shape as no_coverage; additive key.
         uncapturable: @agg.results.select(&:uncapturable?).map { |r| no_coverage_json(r) }
                           .sort_by { |h| [h[:file], h[:line]] },
-        # #10: equivalent mutants the user suppressed — emitted with their stable
-        # id so the user can audit what is silenced (and copy ids for survivors
-        # they want to add). Excluded from the score; never in `survivors`.
+        # Equivalent mutants the user suppressed: emitted with their stable id so
+        # the user can audit what is silenced (and copy ids for survivors they
+        # want to add). Excluded from the score; never in `survivors`.
         ignored: @agg.results.select(&:ignored?).map { |r| ignored_json(r) }
                      .sort_by { |h| [h[:file], h[:line], h[:operator]] },
-        # #11: per-source breakdown (additive; #13 consumes it). Sorted by file so
+        # Per-source breakdown (additive; baseline consumes it). Sorted by file so
         # output is byte-stable. Reuses AggregateResult via by_source.
         per_source: @agg.by_source.map { |file, agg| per_source_json(file, agg) }
                         .sort_by { |h| h[:file] }
       }
-      # #13: additive baseline-delta block, present only with --baseline. Existing
+      # Additive baseline-delta block, present only with --baseline. Existing
       # consumers ignore the extra key; schema_version stays 1.1.
       doc[:baseline] = baseline_json(baseline) if baseline
       "#{JSON.generate(doc)}\n"
     end
 
-    # #23: one self-contained HTML file (inline CSS, no external assets) — the
-    # overall score + summary counts, a per-source table, and every surviving
-    # mutant with its stable id and diff. All source/diff/identifier text is
-    # HTML-escaped (CGI.escapeHTML) so a `<`/`>` in source can never break the
-    # markup. Reuses survivor_json/per_source_json so one run yields one set of
-    # facts regardless of --format.
+    # One self-contained HTML file (inline CSS, no external assets): the overall
+    # score + summary counts, a per-source table, and every surviving mutant with
+    # its stable id and diff. All source/diff/identifier text is HTML-escaped
+    # (CGI.escapeHTML) so a `<`/`>` in source can never break the markup. Reuses
+    # survivor_json/per_source_json so one run yields one set of facts regardless
+    # of --format.
     def html_report
       score = @agg.mutation_score
       survivors = @agg.surviving_mutants.map { |r| survivor_json(r) }
@@ -251,9 +250,9 @@ module Mutineer
     # HTML-escapes any text destined for the document (stdlib CGI).
     def esc(text) = CGI.escapeHTML(text.to_s)
 
-    # #13: the same delta facts the human report prints, for dashboards. new_survivors
+    # The same delta facts the human report prints, for dashboards. new_survivors
     # reuse the ignored_json shape (subject/file/line/operator/token/id) and sort
-    # byte-stably so output doesn't depend on --jobs finish order.
+    # byte-stably so output does not depend on --jobs finish order.
     def baseline_json(delta)
       {
         regressed: delta.regressed,
@@ -300,7 +299,7 @@ module Mutineer
         file: file,
         line: start_line,
         operator: m.operator.to_s,
-        # #10: the stable, copy-pasteable id (next to the human-readable token) so a
+        # The stable, copy-pasteable id (next to the human-readable token) so a
         # user can paste it straight into .mutineer.yml `ignore:`.
         id: result.id,
         token: token,
@@ -308,7 +307,7 @@ module Mutineer
       }
     end
 
-    # An entry under the JSON `ignored:` key — what the user already suppressed.
+    # An entry under the JSON `ignored:` key: what the user already suppressed.
     def ignored_json(result)
       m = result.mutation
       file = result.subject.file
@@ -329,7 +328,7 @@ module Mutineer
     # mutation's 1-based start line, the full original line-block it touches, the
     # spliced mutated block, and a single-line token label for the header.
     def diff_for(m, source)
-      # Byte math (C1): Prism offsets are byte offsets; byteindex/byterindex/
+      # Byte math: Prism offsets are byte offsets; byteindex/byterindex/
       # byteslice keep line splicing correct for multibyte sources.
       line_begin = m.start_offset.zero? ? 0 : (source.byterindex("\n", m.start_offset - 1) || -1) + 1
       line_end   = source.byteindex("\n", m.end_offset) || source.bytesize
@@ -370,9 +369,9 @@ module Mutineer
       out.puts format("Survived:     %-6d  No coverage:   %d", @agg.survived_count, @agg.no_coverage_count)
       out.puts format("Skipped:      %-6d  Errored:       %d", @agg.skipped_invalid_count,
                       @agg.errored_count + @agg.timeout_count)
-      # #9: a broken harness, not a coverage gap — report it distinctly from No coverage.
+      # A broken harness, not a coverage gap: report it distinctly from No coverage.
       out.puts format("Uncapturable: %-6d  (tests failed to run)", @agg.uncapturable_count)
-      # #10: equivalent mutants the user suppressed; excluded from the denominator.
+      # Equivalent mutants the user suppressed; excluded from the denominator.
       out.puts format("Ignored:      %-6d  (equivalent, suppressed)", @agg.ignored_count)
     end
 
@@ -421,10 +420,9 @@ module Mutineer
       parts.join(", ")
     end
 
-    # #11: one line per source after the global summary, so a multi-source run
-    # shows which file is weak. Omitted for a single-source run — the global
-    # summary already says everything (ponytail: no redundant one-line block).
-    # Writes the per-source breakdown.
+    # One line per source after the global summary, so a multi-source run shows
+    # which file is weak. Omitted for a single-source run: the global summary
+    # already says everything (no redundant one-line block).
     #
     # @param out [IO] output stream.
     # @return [void]
@@ -443,7 +441,7 @@ module Mutineer
       end
     end
 
-    # #13: the --baseline delta, appended after the normal report. Names every NEW
+    # The --baseline delta, appended after the normal report. Names every NEW
     # survivor (subject (file:line) operator) and the score delta when it dropped,
     # then a one-line REGRESSION/OK verdict so CI logs show which gate fired.
     def baseline_section(out, delta)

--- a/lib/mutineer/result.rb
+++ b/lib/mutineer/result.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 module Mutineer
-  # Immutable outcome of running one mutant. Seven distinct states:
-  #   killed       — a test failed/errored, so the mutation was caught.
-  #   survived     — every test passed, so the mutation went undetected.
-  #   error        — the child crashed (unhandled exception): exit status 2.
-  #   timeout      — the parent SIGKILLed a child that overran its wall clock.
-  #   skipped      — the mutated source failed to re-parse (invalid); no fork.
-  #   no_coverage  — no test exercises the mutated line; not run, not scored.
-  #   uncapturable — the line's would-be covering test errored during capture
-  #                  (#9), so coverage was lost. Excluded from the
-  #                  denominator exactly like no_coverage, but reported
-  #                  separately: it signals a broken harness (a test that
-  #                  failed to run), not a genuine coverage gap.
-  #   ignored      — a known-equivalent mutant the user suppressed (#10), via
-  #                  an inline `# mutineer:disable-line` comment or a
+  # Immutable outcome of running one mutant. Eight distinct states:
+  #   killed       - a test failed/errored, so the mutation was caught.
+  #   survived     - every test passed, so the mutation went undetected.
+  #   error        - the child crashed (unhandled exception): exit status 2.
+  #   timeout      - the parent SIGKILLed a child that overran its wall clock.
+  #   skipped      - the mutated source failed to re-parse (invalid); no fork.
+  #   no_coverage  - no test exercises the mutated line; not run, not scored.
+  #   uncapturable - the line's would-be covering test errored during capture,
+  #                  so coverage was lost. Excluded from the denominator exactly
+  #                  like no_coverage, but reported separately: it signals a
+  #                  broken harness (a test that failed to run), not a genuine
+  #                  coverage gap.
+  #   ignored      - a known-equivalent mutant the user suppressed, via an
+  #                  inline `# mutineer:disable-line` comment or a
   #                  `.mutineer.yml` `ignore:` id. A pre-fork classification
   #                  (never run); excluded from the denominator so a strong
   #                  file can reach 100%.
@@ -22,14 +22,14 @@ module Mutineer
   # `error` and `skipped` are deliberately distinct: skipped is a pre-fork
   # validity failure (counted separately by the reporter), error is a runtime
   # crash. Never conflate them via `details` string parsing. `no_coverage` and
-  # `uncapturable` are pre-fork selection results (M3/#9): both excluded from
-  # the score denominator.
+  # `uncapturable` are pre-fork selection results: both excluded from the score
+  # denominator.
   #
   # `subject`, `mutation`, and `id` are nil when the Result is built by
   # Isolation/Runner (which only know the outcome); the orchestrator attaches
   # them afterwards via `result.with(subject:, mutation:, id:)` so the Reporter
   # can render survivor diffs and emit the stable id. `id` is the content-based
-  # MutantId (#10).
+  # MutantId.
   Result = Data.define(:status, :details, :subject, :mutation, :id) do
     # Builds a killed result.
     #
@@ -93,12 +93,12 @@ module Mutineer
   end
 
   # Aggregates a flat list of Results into counts, the mutation score, and the
-  # surviving-mutant list. The score denominator is killed + survived ONLY
-  # (KTD-4): no-coverage, uncapturable, skipped (invalid), errored, timeout,
-  # and ignored (#10 equivalent-mutant suppression) are each excluded and
-  # surfaced separately — so suppressing every survivor reaches 100%. An empty
-  # denominator yields a nil score (rendered "N/A"), never 0.0 —
-  # distinguishing "no testable mutants" from "0% killed".
+  # surviving-mutant list. The score denominator is killed + survived ONLY:
+  # no-coverage, uncapturable, skipped (invalid), errored, timeout, and ignored
+  # (equivalent-mutant suppression) are each excluded and surfaced separately,
+  # so suppressing every survivor reaches 100%. An empty denominator yields a
+  # nil score (rendered "N/A"), never 0.0, distinguishing "no testable mutants"
+  # from "0% killed".
   class AggregateResult
     attr_reader :results
 
@@ -151,9 +151,8 @@ module Mutineer
     # @return [Array<Mutineer::Result>] surviving results.
     def surviving_mutants = @results.select(&:survived?)
 
-    # #11: split into { source_file => AggregateResult } so the Reporter
-    # (per-source breakdown) and #13 (per-source roll-up / baseline diff) can
-    # reuse the same aggregate math.
+    # Groups results by source file so the Reporter (per-source breakdown) and
+    # baseline diff can reuse the same aggregate math.
     #
     # @return [Hash<String, Mutineer::AggregateResult>] source-file groups.
     def by_source

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -19,15 +19,15 @@ require "set"
 module Mutineer
   # Orchestrates one mutation end-to-end: apply it textually, validate the
   # result, select its covering test files from the coverage map, then run only
-  # those against the mutated source in an isolated child process (strategy 7a —
+  # those against the mutated source in an isolated child process (strategy
   # whole-file reload via `load`).
   #
   # The source file path is passed explicitly because Mutation carries only byte
-  # offsets, not its file. M3 replaces M2's hardcoded `test_file:` with coverage-
-  # map selection: a mutation whose line no test exercises is :no_coverage (no
-  # fork); otherwise exactly the covering test files run in the child.
+  # offsets, not its file. Coverage-map selection replaces a hardcoded test file:
+  # a mutation whose line no test exercises is :no_coverage (no fork); otherwise
+  # exactly the covering test files run in the child.
   class Runner
-    # Full Phase B orchestration: resolve operators, discover subjects, build the
+    # Full orchestration: resolve operators, discover subjects, build the
     # coverage map, run every mutation, and aggregate. Returns
     # [AggregateResult, source_map]. The CLI then reports + applies the exit code;
     # the integration test asserts directly on the AggregateResult.
@@ -41,25 +41,25 @@ module Mutineer
     def self.execute(config)
       operator_classes = MutatorRegistry.resolve(config.operators || MutatorRegistry::DEFAULT_NAMES)
 
-      # #27: the external backend runs the suite as a subprocess in the app's own
-      # runtime — it does no in-process boot/require or coverage build, so branch
-      # before any of that. The in-process path below is untouched.
+      # External backend: run the suite as a subprocess in the app's own runtime.
+      # It does no in-process boot/require or coverage build, so branch before any
+      # of that. The in-process path below is untouched.
       return execute_external(config, operator_classes) if config.test_command
 
-      # #26/#27 Phase 2a: the daemon backend boots the app ONCE in a persistent
-      # subprocess under the app's bundle and forks per mutant. Tool-side we only
-      # discover jobs + build payloads (Prism), so branch before any in-process boot.
+      # Daemon backend: boot the app ONCE in a persistent subprocess under the
+      # app's bundle and fork per mutant. Tool-side we only discover jobs + build
+      # payloads (Prism), so branch before any in-process boot.
       return execute_daemon(config, operator_classes) if config.daemon
 
       # Boot mode: require the boot file ONCE so the app env (e.g. Rails) is booted
       # in the parent and inherited by every fork. Do NOT manually require the
-      # sources — under Zeitwerk a manual require of an autoloadable file raises;
+      # sources. Under Zeitwerk a manual require of an autoloadable file raises;
       # the booted env autoloads them, and subject discovery is a static Prism
       # parse that needs nothing loaded. Standalone mode requires the sources as
       # before so their classes exist for the children to inherit.
       if config.boot
-        # #7: under --rails an unset RAILS_ENV boots development, where the test
-        # suite isn't loaded — coverage comes back empty and EVERY mutant is
+        # Under --rails an unset RAILS_ENV boots development, where the test
+        # suite is not loaded. Coverage comes back empty and EVERY mutant is
         # falsely reported no_coverage (score N/A, exit 0). Default it to test.
         ensure_rails_env(config)
 
@@ -104,10 +104,11 @@ module Mutineer
 
       jobs = filter_since(jobs, source_map, config) if config.since
 
-      # C3: 7a writes mutineer_mutant*.rb into each source dir (so require_relative
-      # resolves). A SIGKILL'd child skips the tempfile's ensure-unlink, orphaning
-      # it. `ensure` is unreliable vs SIGKILL, so the PARENT sweeps each source dir
-      # before and after the run — orphans are impossible after a normal run.
+      # Whole-file reload writes mutineer_mutant*.rb into each source dir (so
+      # require_relative resolves). A SIGKILL'd child skips the tempfile's
+      # ensure-unlink, orphaning it. `ensure` is unreliable vs SIGKILL, so the
+      # PARENT sweeps each source dir before and after the run. Orphans are
+      # impossible after a normal run.
       dirs = source_dirs(config)
       sweep_orphans(dirs)
 
@@ -136,12 +137,12 @@ module Mutineer
     end
 
     # Collect every (subject, mutation, id) up front so a backend can run them.
-    # #10: a mutant the user marked known-equivalent (inline disable-line comment
-    # or .mutineer.yml ignore id) is classified :ignored here and NEVER run — it is
+    # A mutant the user marked known-equivalent (inline disable-line comment or
+    # .mutineer.yml ignore id) is classified :ignored here and NEVER run. It is
     # removed from the killed+survived denominator so a strong file reaches 100%.
     # The stable id is computed per subject (occurrence needs the full list) and
     # carried on every job so the parent can reattach it after the run. Shared by
-    # the in-process and external (#27) backends so job selection can never drift.
+    # the in-process and external backends so job selection can never drift.
     #
     # @return [Array(Array, Array<Result>, Hash<String,String>)] jobs, ignored, source_map.
     def self.collect_jobs(config, operator_classes)
@@ -168,12 +169,12 @@ module Mutineer
       [jobs, ignored_results, source_map]
     end
 
-    # #27: external backend orchestration. Runs each mutant's whole-file mutation on
+    # External backend orchestration. Runs each mutant's whole-file mutation on
     # disk (crash-safe swap) and executes the user's --test-command as a subprocess
-    # in the app's own runtime. Serial by construction (KTD-5: one shared DB, no
-    # per-worker isolation yet). No coverage narrowing — every mutant runs the full
-    # --test set (KTD-6); the score is therefore an upper bound and not comparable
-    # to an in-process run (the CLI discloses this).
+    # in the app's own runtime. Serial by construction (one shared DB, no
+    # per-worker isolation yet). No coverage narrowing: every mutant runs the full
+    # --test set; the score is therefore an upper bound and not comparable to an
+    # in-process run (the CLI discloses this).
     #
     # @param config [Mutineer::Config] run configuration (test_command set).
     # @param operator_classes [Array<Class>] resolved operators.
@@ -182,7 +183,7 @@ module Mutineer
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
       dirs      = source_dirs(config)
 
-      # Heal any file a prior hard-killed run left mutated BEFORE reading source —
+      # Heal any file a prior hard-killed run left mutated BEFORE reading source.
       # collect_jobs computes mutation offsets/ids from the on-disk bytes, so a
       # still-mutated file would yield garbage offsets against the later-healed
       # source. Heal first, then discover jobs from the clean tree.
@@ -192,10 +193,10 @@ module Mutineer
       jobs = filter_since(jobs, source_map, config) if config.since
 
       # Calibrate the per-mutant timeout from the clean run (a real suite far
-      # outlasts the 10s in-process fork budget), and abort if it isn't green.
-      # ponytail: 3x the clean run, floor 30s, ceiling 300s — a heuristic. The
-      # floor covers a fast suite; the ceiling bounds a hung mutant (infinite loop)
-      # so a handful can't stall a serial run for ~45min on a slow suite.
+      # outlasts the 10s in-process fork budget), and abort if it is not green.
+      # 3x the clean run, floor 30s, ceiling 300s: a heuristic. The floor covers
+      # a fast suite; the ceiling bounds a hung mutant (infinite loop) so a
+      # handful cannot stall a serial run for ~45min on a slow suite.
       smoke_elapsed = ExternalBackend.smoke_check!(config.test_command, abs_tests)
       timeout = [[smoke_elapsed * 3, 30].max, 300].min.ceil
 
@@ -205,7 +206,7 @@ module Mutineer
           r = run_external(subject, mutation, config.test_command, abs_tests,
                            timeout: timeout, verbose: config.verbose)
           results << r.with(subject: subject, mutation: mutation, id: id)
-          break if config.fail_fast && r.survived? # #21: stop at the first survivor
+          break if config.fail_fast && r.survived? # stop at the first survivor
         end
       ensure
         FileSwap.restore_orphans(dirs)
@@ -214,11 +215,11 @@ module Mutineer
       [AggregateResult.new(results + ignored_results), source_map]
     end
 
-    # Runs one mutant through the external backend: apply the whole-file mutation on
-    # disk, run the command, restore. KTD-8: an invalid (non-reparsing) mutant would
+    # Runs one mutant through the external backend: apply the whole-file mutation
+    # on disk, run the command, restore. An invalid (non-reparsing) mutant would
     # fail to load and score a false `killed`, so skip it tool-side (Prism, already
-    # cheap) and never write the file — preserving the `skipped` verdict the
-    # in-process path gives at runner.rb's pre-fork check.
+    # cheap) and never write the file, preserving the `skipped` verdict the
+    # in-process path gives at the pre-fork check.
     #
     # @return [Mutineer::Result] verdict for this mutant.
     def self.run_external(subject, mutation, command, abs_tests, timeout:, verbose:)
@@ -244,18 +245,18 @@ module Mutineer
       jobs = filter_since(jobs, source_map, config) if config.since
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
 
-      # Build the coverage map once (app-side). nil when the build fails — runners
+      # Build the coverage map once (app-side). nil when the build fails: runners
       # fall back to the full --test set (and emit a stderr warning) rather than
       # mis-scoring everything as no_coverage.
       coverage_map = daemon_coverage_map(config, abs_tests)
 
-      # #26/U6: worker count = resolved --jobs, capped at the job count (no idle
-      # daemons). >1 → N concurrent daemon handles, each on its OWN worker DB (V6:
-      # N-handles, the spike-proven shape). 1 → the serial single-daemon path.
-      # --fail-fast forces serial: parallel's stop flag fires on the first survivor
-      # by WALL-CLOCK, not input index, so the verdict set would diverge from serial
-      # (a different, non-deterministic survivor set/score) — the "identical to
-      # --jobs 1" guarantee below only holds when fail-fast can't race.
+      # Worker count = resolved --jobs, capped at the job count (no idle daemons).
+      # >1 → N concurrent daemon handles, each on its OWN worker DB (N-handles, the
+      # spike-proven shape). 1 → the serial single-daemon path. --fail-fast forces
+      # serial: parallel's stop flag fires on the first survivor by WALL-CLOCK, not
+      # input index, so the verdict set would diverge from serial (a different,
+      # non-deterministic survivor set/score). The "identical to --jobs 1" guarantee
+      # below only holds when fail-fast cannot race.
       worker_count = [config.jobs || 1, 1].max
       worker_count = 1 if config.fail_fast
       worker_count = [worker_count, jobs.size].min if jobs.size.positive?
@@ -272,7 +273,7 @@ module Mutineer
 
     # Build the coverage map via a short-lived daemon (boots the app once, captures
     # per-test coverage app-side, ships the map back). Returns a query-only
-    # CoverageMap, or nil when the build fails / returns empty — callers then run the
+    # CoverageMap, or nil when the build fails / returns empty. Callers then run the
     # full --test set. Coverage-build IPC has no wall-clock (same limitation as
     # in-process build_via_fork). A normal nonempty map scores like in-process;
     # nil falls back to the full suite (more testing, not comparable).
@@ -313,7 +314,7 @@ module Mutineer
     private_class_method :warn_daemon_coverage_fallback
 
     # Serial daemon path: one daemon (worker 0), one mutant at a time. Honors
-    # --fail-fast (#21: stop at the first survivor).
+    # --fail-fast (stop at the first survivor).
     #
     # @return [Array<Mutineer::Result>] results in input order.
     def self.run_daemon_serial(jobs, config, abs_tests, coverage_map, source_map)
@@ -367,7 +368,7 @@ module Mutineer
     end
 
     # Build the payload for one job, run it on the given daemon/worker, and attach
-    # the subject/mutation/id — the shared body of both daemon paths.
+    # the subject/mutation/id. Shared body of both daemon paths.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
@@ -378,11 +379,12 @@ module Mutineer
       subject, mutation, id = job
       source  = source_map[subject.file]
       mutated = mutation.apply(source)
-      # KTD-8 (carried): skip an invalid mutant tool-side — never ship a payload that
-      # would fail to load and read as a false `killed`.
-      # #26/U7: narrow to covering tests (shared with the in-process path via
-      # coverage_selection, so scores match). :verdict = no_coverage/uncapturable, no
-      # fork. No map (build failed) → run the full --test set (fallback, not narrowed).
+      # Skip an invalid mutant tool-side: never ship a payload that would fail to
+      # load and read as a false `killed`.
+      # Narrow to covering tests (shared with the in-process path via
+      # coverage_selection, so scores match). :verdict = no_coverage/uncapturable,
+      # no fork. No map (build failed) → run the full --test set (fallback, not
+      # narrowed).
       sel = coverage_map && coverage_selection(subject.file, mutation, subject, source, coverage_map)
       r =
         if Parser.parse_string(mutated).errors.any?
@@ -401,15 +403,15 @@ module Mutineer
     end
 
     # Coverage-based test selection, shared by the in-process ({run}) and daemon
-    # paths so both narrow identically (score parity, U7/V5). Returns
+    # paths so both narrow identically (score parity). Returns
     # `[:run, abs_test_paths]` when some test covers the mutant's line, or
     # `[:verdict, Result]` (no_coverage / uncapturable) when none do.
     #
-    # #9/#25: an empty selection is `:uncapturable` (not `:no_coverage`) when the
-    # mutant's enclosing method body got coverage from no *successful* capture but a
-    # sibling test failed to capture — the coverage was lost, not absent. Both are
-    # excluded from the score denominator, so this distinction is reporting-only and
-    # never changes the daemon-vs-in-process score.
+    # An empty selection is `:uncapturable` (not `:no_coverage`) when the
+    # mutant's enclosing method body got coverage from no *successful* capture but
+    # a sibling test failed to capture: the coverage was lost, not absent. Both are
+    # excluded from the score denominator, so this distinction is reporting-only
+    # and never changes the daemon-vs-in-process score.
     #
     # @param source_file [String] the mutated source file path.
     # @param mutation [Mutineer::Mutation] the mutation (for its line offset).
@@ -447,10 +449,10 @@ module Mutineer
         source_dirs: source_dirs(config), # so the daemon can sweep orphan mutant temps
         framework: config.framework,
         rails: config.rails,
-        # #26/U5: schema for per-worker DB isolation. Sent when present; the daemon
+        # Schema for per-worker DB isolation. Sent when present; the daemon
         # skips worker-DB schema loading if the path is absent (e.g. structure.sql apps).
         schema: daemon_schema_path(config),
-        # #26/U7: coverage narrowing. Only the short-lived map-building daemon starts
+        # Coverage narrowing. Only the short-lived map-building daemon starts
         # Coverage (before boot); worker daemons boot with it OFF (no wasted
         # instrumentation/memory across every mutant fork). `sources`/`tests` are the
         # map-build inputs.
@@ -461,9 +463,9 @@ module Mutineer
     end
 
     # Absolute path to the app's `db/schema.rb` if it exists, else nil. Used by the
-    # daemon to schema-load each fork's isolated worker database (#26/U5). Only
-    # `schema.rb` is supported this pass; `structure.sql` apps get nil and fall back to
-    # whatever the worker DB already holds (Postgres provisioning is U10).
+    # daemon to schema-load each fork's isolated worker database. Only `schema.rb`
+    # is supported this pass; `structure.sql` apps get nil and fall back to
+    # whatever the worker DB already holds.
     #
     # @param config [Mutineer::Config] the run config.
     # @return [String, nil] absolute schema path or nil.
@@ -472,8 +474,8 @@ module Mutineer
       File.exist?(path) ? path : nil
     end
 
-    # Map a daemon verdict string to a Result. The daemon reports the four run-time
-    # states it can decide (KTD-5); pre-fork states (skipped/no_coverage/…) are
+    # Map a daemon verdict string to a Result. The daemon reports the four
+    # run-time states it can decide; pre-fork states (skipped/no_coverage/…) are
     # resolved tool-side before a request is ever sent.
     def self.daemon_result(verdict)
       case verdict
@@ -550,9 +552,9 @@ module Mutineer
       end.uniq
     end
 
-    # #7: when --rails is on and RAILS_ENV is unset, default it to "test" (and
-    # say so) before the app boots — otherwise it boots development and nothing
-    # is measured. An explicitly-set RAILS_ENV is always respected.
+    # When --rails is on and RAILS_ENV is unset, default it to "test" (and say so)
+    # before the app boots. Otherwise it boots development and nothing is measured.
+    # An explicitly-set RAILS_ENV is always respected.
     def self.ensure_rails_env(config)
       return unless config.rails
       return unless ENV["RAILS_ENV"].nil? || ENV["RAILS_ENV"].empty?
@@ -561,9 +563,9 @@ module Mutineer
       warn "[mutineer] RAILS_ENV was unset; defaulting to 'test' for --rails."
     end
 
-    # The unique absolute directories holding the sources — the sweep target for
-    # both orphan mechanisms (in-process mutant tempfiles and external backup
-    # files). Shared so the path-expansion rule can't drift between the two paths.
+    # The unique absolute directories holding the sources. Sweep target for both
+    # orphan mechanisms (in-process mutant tempfiles and external backup files).
+    # Shared so the path-expansion rule cannot drift between the two paths.
     #
     # @api private
     # @param config [Mutineer::Config] run configuration.
@@ -601,13 +603,13 @@ module Mutineer
       source  = File.read(source_file)
       mutated = mutation.apply(source)
 
-      # Validity rule: a mutant that doesn't re-parse is skipped before forking.
+      # Validity rule: a mutant that does not re-parse is skipped before forking.
       return Result.skipped if Parser.parse_string(mutated).errors.any?
 
       # Coverage selection (both standalone and boot mode): a mutation on a line
       # no test exercises is :no_coverage (no fork); otherwise exactly the
       # covering test files run in the child. Shared with the daemon path so both
-      # narrow identically (score parity, U7/V5).
+      # narrow identically (score parity).
       kind, payload = coverage_selection(source_file, mutation, subject, source, coverage_map)
       return payload if kind == :verdict
 
@@ -634,9 +636,9 @@ module Mutineer
       return unless defined?(ActiveRecord::Base)
 
       base = ActiveRecord::Base
-      # #8: clearing connections here drops an open transactional-fixture
+      # Clearing connections here drops an open transactional-fixture
       # transaction, so the test loses its fixture rows and fails. Skip the clear
-      # when a transaction is open; otherwise clear (v0.2 per-fork write-safety).
+      # when a transaction is open; otherwise clear (per-fork write-safety).
       return if fixture_transaction_open?(base)
 
       base.connection_handler.clear_all_connections!
@@ -646,9 +648,9 @@ module Mutineer
     private_class_method :reconnect_active_record
 
     # Pure, injectable predicate: true when a transactional-fixture transaction is
-    # already open on the connection. Keys off open_transactions (KTD-2) so it is
-    # correct whenever the transaction exists, regardless of when it opened. Any
-    # probe error degrades safe to false -> caller clears (existing behaviour).
+    # already open on the connection. Keys off open_transactions so it is correct
+    # whenever the transaction exists, regardless of when it opened. Any probe
+    # error degrades safe to false -> caller clears (existing behaviour).
     def self.fixture_transaction_open?(base)
       pool = base.connection_pool
       pool.active_connection? && base.connection.open_transactions.positive?

--- a/lib/mutineer/worker_pool.rb
+++ b/lib/mutineer/worker_pool.rb
@@ -3,17 +3,17 @@
 require_relative "result"
 
 module Mutineer
-  # Fixed-size fork pool (KTD1/KTD2). `run` forks up to `size` children at
-  # once; each child runs the block on one work item, marshals its Result to a
-  # private pipe, and exits. The parent reaps any finished child with
-  # Process.wait2(-1), opening exactly one slot per reap, then refills.
-  # Results are returned in the SAME ORDER as `items` regardless of finish
-  # order, so verdicts are identical to a serial run (R4) and downstream output
-  # is stable.
+  # Fixed-size fork pool. `run` forks up to `size` children at once; each child
+  # runs the block on one work item, marshals its Result to a private pipe, and
+  # exits. The parent drains pipes with IO.select and reaps each finished child
+  # by known pid (never wait2(-1), which would steal the host suite's children),
+  # opening exactly one slot per reap, then refills. Results are returned in the
+  # SAME ORDER as `items` regardless of finish order, so verdicts are identical
+  # to a serial run and downstream output is stable.
   #
   # The block is run inside the child via `yield(*items[i])`; whatever it
   # returns (a Result) is the marshaled payload. Per-mutant timeout is handled
-  # one level down by Isolation (KTD2) — the pool adds no separate wall clock.
+  # one level down by Isolation. The pool adds no separate wall clock.
   class WorkerPool
     # Builds a pool.
     #
@@ -27,7 +27,7 @@ module Mutineer
     # @param items [Array<Array>] work items.
     # @param stop_when [Proc, nil] called with each collected Result; when it
     #   returns truthy, no further items are scheduled and the run drains and
-    #   returns early (#21 --fail-fast). Unscheduled slots stay nil.
+    #   returns early (--fail-fast). Unscheduled slots stay nil.
     # @yieldparam item [Array] one work item.
     # @return [Array<Mutineer::Result>] results in input order (nil for any item
     #   left unscheduled by an early stop).
@@ -51,15 +51,15 @@ module Mutineer
 
     private
 
-    # R1: the child must ALWAYS hard-exit. If yield raises, marshal an error
-    # Result and exit! in `ensure` — otherwise the child unwinds normally and
-    # our Minitest at_exit autorun re-runs the parent suite inside the worker,
+    # The child must ALWAYS hard-exit. If yield raises, marshal an error Result
+    # and exit! in `ensure`. Otherwise the child unwinds normally and our
+    # Minitest at_exit autorun re-runs the parent suite inside the worker,
     # losing the real error.
     def fill(items, queue, running)
       while running.size < @size && !queue.empty?
         idx = queue.shift
         rd, wr = IO.pipe
-        rd.binmode # #19: Marshal output is binary — keep the pipe byte-exact
+        rd.binmode # Marshal output is binary: keep the pipe byte-exact
         wr.binmode
         begin
           pid = fork do
@@ -94,13 +94,13 @@ module Mutineer
       end
     end
 
-    # Drain pipes with IO.select and reap a child only on EOF (#4). The old
-    # code reaped first and read after — but a child whose payload exceeds the
-    # OS pipe buffer (~64KB) blocks on `write` before it can exit, so it was
-    # never reaped and the pool deadlocked. Reading concurrently keeps the
-    # pipe drained so the child can finish and exit; EOF means it closed its
-    # write end (done writing). We waitpid only OUR known pids (R6: never
-    # wait2(-1), which would steal the host suite's children).
+    # Drain pipes with IO.select and reap a child only on EOF. The old code
+    # reaped first and read after, but a child whose payload exceeds the OS pipe
+    # buffer (~64KB) blocks on `write` before it can exit, so it was never reaped
+    # and the pool deadlocked. Reading concurrently keeps the pipe drained so the
+    # child can finish and exit; EOF means it closed its write end (done writing).
+    # We waitpid only OUR known pids (never wait2(-1), which would steal the host
+    # suite's children).
     def reap(results, running)
       return if running.empty?
 
@@ -116,7 +116,7 @@ module Mutineer
             rd.close
             Process.waitpid(pid) # reap the now-finished child (no zombie)
             running.delete(pid)
-            # Return the collected Result so the caller's stop_when (#21) can see it.
+            # Return the collected Result so the caller's stop_when can see it.
             return results[idx] = decode(buf)
           end
           buf << chunk
@@ -124,8 +124,8 @@ module Mutineer
       end
     end
 
-    # R6: a partial/garbage Marshal stream (dead worker) must not crash the
-    # pool — degrade to an error Result.
+    # A partial/garbage Marshal stream (dead worker) must not crash the pool.
+    # Degrade to an error Result.
     # @param data [String] marshaled payload.
     # @return [Mutineer::Result] decoded result or error result.
     def decode(data)


### PR DESCRIPTION
## What
Strip ticket/phase/KTD history tags from orchestration-file comments. Prefer present-tense YARD contracts.

## Why
History-laden comments already disagreed with shipped behavior once (daemon coverage). Noise slows review and invites more drift.

## How
- Rewrite class/method docs on runner, CLI, daemon pair, coverage map, reporter, result, rails_worker_db, and related modules
- Keep score nil-vs-0.0, exit contracts, daemon-without-Prism, FileSwap, Marshal binmode, Rails isolation hazards
- Soften one Postgres NotImplementedError string (no ticket jargon)
- yard:strict + full suite green locally

Closes #57

## Test plan
- [x] `bundle exec rake test` (409 runs)
- [x] `bundle exec rake yard:strict`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->