### PR TITLE
chore(docs): sync renamed dt- skill references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ suggest merge until this is done on the current head.
 
 ### Before opening a new PR
 
-Run `/dt-pre-pr-gate` on the exact PR-head commit:
+Run `/dt-ship-pre-pr-gate` on the exact PR-head commit:
 
 1. `/ce-code-review` — fix findings  
 2. `/ie-review` — fix findings  
@@ -58,7 +58,7 @@ Then `gh pr create`. A gate run is stale after any later commit; re-run.
    - Never resolve silently
 3. **CI green** on the head SHA
 4. Readiness skills only after 1–3: `check-pr-comments`,
-   `dt-address-PR-for-readiness`. Human merges.
+   `dt-ship-pr-readiness`. Human merges.
 
 **Stacked PRs:** gate each PR from the bottom of the stack up. After fixing
 a lower PR, restack dependents and re-gate them.


### PR DESCRIPTION
## What

Syncs this repo's references to the personal `dt-` skills, which were regrouped
into families so they are findable from the slash menu.

| Was | Now |
|---|---|
| `dt-pre-pr-gate` | `dt-ship-pre-pr-gate` |
| `dt-address-PR-for-readiness` | `dt-ship-pr-readiness` |
| `dt-merge-ready-pr` | `dt-ship-merge-ready` |
| `dt-work-to-review-to-pr` | `dt-ship-work-to-pr` |
| `dt-staging-qa` | `dt-ship-staging-qa` |
| `dt-promote-release` | `dt-ship-promote-release` |
| `dt-create-issue` | `dt-issue-create` |
| `dt-end-session` | `dt-session-end` |
| `dt-project-bootstrap` | `dt-repo-bootstrap` |
| `dt-agents-md` | `dt-repo-agents-md` |
| `dt-deps-review` | `dt-repo-deps-review` |
| `dt-deep-analysis` | `dt-repo-deep-analysis` |
| `dt-demo-reel` | `dt-visual-reel` |

## Why

Typing `/dt-` returned a flat, unsorted list. Skills now group into five
families (`dt-ship-`, `dt-issue-`, `dt-repo-`, `dt-session-`, `dt-visual-`), so
`/dt-ship` narrows to exactly the shipping family. The family word also becomes
the plugin name if a family is ever published to a marketplace, where skills are
namespaced as `plugin:skill`.

Without this change, the workflow contract here points at skill names that no
longer exist, and an agent following it would silently fail to find them.

## How

Mechanical string substitution in markdown only. No code, no behaviour, no
tests touched.

Verified across all skills before the sync: every skill directory name matches
its frontmatter `name:`, zero stale references remain, and no double-prefixes
(`dt-ship-ship-…`) were introduced. Dated records (STATUS files, archived docs,
historical plans) were deliberately left untouched, since they describe what was
run under the names that existed at the time.

## Note on the pre-PR gate

The local ce/ie/cubic gate was **explicitly waived by David in chat** for this
PR, per the escape clause in `dt-ship-pre-pr-gate` ("skipping for docs-only is
invalid *unless the user explicitly waives it in chat for that PR*"). The diff
is a markdown rename sync with no code to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRzzhdPQWHbEZd9qQ9zrz9

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->