### PR TITLE
refactor: split daemon orchestration out of Runner (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ All notable changes to this project are documented here. The format is based on
 ### Changed
 - **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
   (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now
-  lives in `Mutineer::DaemonBackend`, mirroring `ExternalBackend`. `Runner` keeps
-  job collection, coverage selection and the single in-process mutant run, and
-  drops from 662 to 439 lines. No CLI or behaviour change (#58).
+  lives in `Mutineer::DaemonBackend`. `Runner` keeps job collection, coverage
+  selection and the single in-process mutant run, and drops from 662 to 439 lines.
+  The external backend's orchestration stays on `Runner` for now, so the two
+  backends are not yet symmetrical. No CLI or behaviour change (#58).
 - **Comment diet on orchestration files** — present-tense YARD contracts; drop
   ticket/phase/KTD history tags from runner, CLI, daemon pair, coverage map,
   reporter, result, and related modules. Safety and score invariants kept (#57).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,28 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-### Fixed
-- **Daemon parallel worker crash keeps the mutant** — a raise inside a parallel
-  daemon worker used to leave a nil slot that `compact` dropped, so the mutant
-  vanished from the aggregate (not even `:error`). The worker now records
-  `Result.error` and every input slot is retained, matching `WorkerPool`.
-
 ### Changed
 - **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
   (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now
   lives in `Mutineer::DaemonBackend`. `Runner` keeps job collection, coverage
   selection and the single in-process mutant run, and drops from 662 to 439 lines.
   The external backend's orchestration stays on `Runner` for now, so the two
-  backends are not yet symmetrical. No CLI or behaviour change (#58).
-  Internal-only removals: `Runner.execute_daemon`, `Runner.daemon_coverage_map`
-  and `Runner::DAEMON_TIMEOUT` no longer exist. They were never documented —
-  the supported programmatic contract is the JSON report, the stable mutant ids
-  and the exit codes — so only code calling `Runner` internals directly is
-  affected.
+  backends are not yet symmetrical. The move itself changes no CLI flag, no
+  output and no verdict (#58); the one behaviour change on this branch is the
+  daemon crash handling below. Internal-only removals:
+  `Runner.execute_daemon`, `Runner.daemon_coverage_map` and
+  `Runner::DAEMON_TIMEOUT` no longer exist. They were never documented — the
+  supported programmatic contract is the JSON report, the stable mutant ids and
+  the exit codes — so only code calling `Runner` internals directly is affected.
+- **A daemon crash while running one mutant no longer ends the whole run** — it
+  used to propagate and abort with a backtrace, on both `--jobs 1` and
+  `--jobs N`. That mutant is now scored `:error` and the run continues, matching
+  `WorkerPool` and the daemon's own in-band crash reply. Errors stay outside the
+  score denominator. A daemon that exhausts its restart budget still ends the
+  run: `DaemonClient` raises after `MAX_RESTARTS`, and scoring the remaining
+  mutants against a dead daemon would report a score covering a fraction of the
+  work. Both daemon paths share one classification, so `--jobs N` still matches
+  `--jobs 1`.
 - **Comment diet on orchestration files** — present-tense YARD contracts; drop
   ticket/phase/KTD history tags from runner, CLI, daemon pair, coverage map,
   reporter, result, and related modules. Safety and score invariants kept (#57).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,12 @@ All notable changes to this project are documented here. The format is based on
   lives in `Mutineer::DaemonBackend`. `Runner` keeps job collection, coverage
   selection and the single in-process mutant run, and drops from 662 to 439 lines.
   The external backend's orchestration stays on `Runner` for now, so the two
-  backends are not yet symmetrical. The move itself changes no CLI flag, no
-  output and no verdict (#58); the one behaviour change on this branch is the
-  daemon crash handling below. Internal-only removals:
-  `Runner.execute_daemon`, `Runner.daemon_coverage_map` and
-  `Runner::DAEMON_TIMEOUT` no longer exist. They were never documented — the
-  supported programmatic contract is the JSON report, the stable mutant ids and
-  the exit codes — so only code calling `Runner` internals directly is affected.
-- **A daemon crash while running one mutant no longer ends the whole run** — it
-  used to propagate and abort with a backtrace, on both `--jobs 1` and
-  `--jobs N`. That mutant is now scored `:error` and the run continues, matching
-  `WorkerPool` and the daemon's own in-band crash reply. Errors stay outside the
-  score denominator. A daemon that exhausts its restart budget still ends the
-  run: `DaemonClient` raises after `MAX_RESTARTS`, and scoring the remaining
-  mutants against a dead daemon would report a score covering a fraction of the
-  work. Both daemon paths share one classification, so `--jobs N` still matches
-  `--jobs 1`.
+  backends are not yet symmetrical. No CLI or behaviour change (#58).
+  Internal-only removals: `Runner.execute_daemon`, `Runner.daemon_coverage_map`
+  and `Runner::DAEMON_TIMEOUT` no longer exist. They were never documented —
+  the supported programmatic contract is the JSON report, the stable mutant ids
+  and the exit codes — so only code calling `Runner` internals directly is
+  affected.
 - **Comment diet on orchestration files** — present-tense YARD contracts; drop
   ticket/phase/KTD history tags from runner, CLI, daemon pair, coverage map,
   reporter, result, and related modules. Safety and score invariants kept (#57).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Changed
+- **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
+  (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now
+  lives in `Mutineer::DaemonBackend`, mirroring `ExternalBackend`. `Runner` keeps
+  job collection, coverage selection and the single in-process mutant run, and
+  drops from 662 to 439 lines. No CLI or behaviour change (#58).
 - **Comment diet on orchestration files** — present-tense YARD contracts; drop
   ticket/phase/KTD history tags from runner, CLI, daemon pair, coverage map,
   reporter, result, and related modules. Safety and score invariants kept (#57).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project are documented here. The format is based on
   selection and the single in-process mutant run, and drops from 662 to 439 lines.
   The external backend's orchestration stays on `Runner` for now, so the two
   backends are not yet symmetrical. No CLI or behaviour change (#58).
+  Internal-only removals: `Runner.execute_daemon`, `Runner.daemon_coverage_map`
+  and `Runner::DAEMON_TIMEOUT` no longer exist. They were never documented —
+  the supported programmatic contract is the JSON report, the stable mutant ids
+  and the exit codes — so only code calling `Runner` internals directly is
+  affected.
 - **Comment diet on orchestration files** — present-tense YARD contracts; drop
   ticket/phase/KTD history tags from runner, CLI, daemon pair, coverage map,
   reporter, result, and related modules. Safety and score invariants kept (#57).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **Daemon parallel worker crash keeps the mutant** — a raise inside a parallel
+  daemon worker used to leave a nil slot that `compact` dropped, so the mutant
+  vanished from the aggregate (not even `:error`). The worker now records
+  `Result.error` and every input slot is retained, matching `WorkerPool`.
+
 ### Changed
 - **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
   (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require_relative "parser"
+require_relative "result"
+require_relative "coverage_map"
+require_relative "daemon_client"
+
+module Mutineer
+  # Daemon execution backend. Boots the app ONCE in a persistent subprocess under
+  # the app's own bundle and forks per mutant, so a Rails run pays the boot cost
+  # once instead of per mutant. Tool-side this only discovers jobs and builds the
+  # ready-to-`load` payload (Prism); the daemon needs no Prism/mutineer.
+  #
+  # When jobs > 1 each worker runs against its OWN database, which is what makes
+  # `--jobs N` safe under Rails (#26): parallel verdicts are identical to serial.
+  #
+  # Job collection, `--since` filtering and coverage selection stay on {Runner} and
+  # are called from here, so the daemon path can never drift from the in-process
+  # path on which mutants run or which tests narrow a mutant (score parity).
+  module DaemonBackend
+    # Default per-mutant timeout on the daemon path (seconds). Coverage narrowing
+    # usually keeps each job short; this still covers a slow suite or full-suite
+    # fallback when the coverage map is unavailable.
+    TIMEOUT = 60
+
+    # Full daemon run: collect jobs, build the coverage map once, then execute
+    # serially or across N worker daemons. Fail-fast forces serial so the survivor
+    # set matches jobs 1.
+    #
+    # @param config [Mutineer::Config] run configuration (daemon set).
+    # @param operator_classes [Array<Class>] resolved operators.
+    # @return [Array(Mutineer::AggregateResult, Hash<String,String>)] aggregate and source map.
+    def self.execute(config, operator_classes)
+      jobs, ignored_results, source_map = Runner.collect_jobs(config, operator_classes)
+      jobs = Runner.filter_since(jobs, source_map, config) if config.since
+      abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
+
+      # Build the coverage map once (app-side). nil when the build fails: runners
+      # fall back to the full --test set (and emit a stderr warning) rather than
+      # mis-scoring everything as no_coverage.
+      coverage_map = build_coverage_map(config, abs_tests)
+
+      # Worker count = resolved --jobs, capped at the job count (no idle daemons).
+      # >1 → N concurrent daemon handles, each on its OWN worker DB (N-handles, the
+      # spike-proven shape). 1 → the serial single-daemon path. --fail-fast forces
+      # serial: parallel's stop flag fires on the first survivor by WALL-CLOCK, not
+      # input index, so the verdict set would diverge from serial (a different,
+      # non-deterministic survivor set/score). The "identical to --jobs 1" guarantee
+      # below only holds when fail-fast cannot race.
+      worker_count = [config.jobs || 1, 1].max
+      worker_count = 1 if config.fail_fast
+      worker_count = [worker_count, jobs.size].min if jobs.size.positive?
+
+      results =
+        if worker_count > 1
+          run_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
+        else
+          run_serial(jobs, config, abs_tests, coverage_map, source_map)
+        end
+
+      [AggregateResult.new(results + ignored_results), source_map]
+    end
+
+    # Build the coverage map via a short-lived daemon (boots the app once, captures
+    # per-test coverage app-side, ships the map back). Returns a query-only
+    # CoverageMap, or nil when the build fails / returns empty. Callers then run the
+    # full --test set. Coverage-build IPC has no wall-clock (same limitation as
+    # in-process build_via_fork). A normal nonempty map scores like in-process;
+    # nil falls back to the full suite (more testing, not comparable).
+    #
+    # @param config [Mutineer::Config] the run config.
+    # @param abs_tests [Array<String>] absolute --test paths.
+    # @return [Mutineer::CoverageMap, nil]
+    def self.build_coverage_map(config, abs_tests)
+      client = DaemonClient.new(boot: boot_config(config, abs_tests, coverage: true),
+                                app_root: config.project_root).start
+      data = begin
+        client.coverage
+      ensure
+        client.quit
+      end
+      unless data && !(data["map"] || {}).empty?
+        reason = data.is_a?(Hash) && data["error"] ? data["error"] : "empty map"
+        warn_coverage_fallback(reason)
+        return nil
+      end
+
+      CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
+                            project_root: config.project_root)
+    rescue DaemonBootError => e
+      warn_coverage_fallback("#{e.class}: #{e.message}")
+      nil
+    end
+
+    # Stderr note when daemon coverage is unavailable (full --test set per mutant).
+    #
+    # @api private
+    # @param reason [String] short cause (boot error message, empty map, …).
+    # @return [void]
+    def self.warn_coverage_fallback(reason = "unknown")
+      warn "[mutineer] daemon coverage map unavailable (#{reason}); running every " \
+           "mutant against the full --test set (score not comparable to an in-process run)."
+    end
+    private_class_method :warn_coverage_fallback
+
+    # Serial path: one daemon (worker 0), one mutant at a time. Honors --fail-fast
+    # (stop at the first survivor).
+    #
+    # @return [Array<Mutineer::Result>] results in input order.
+    def self.run_serial(jobs, config, abs_tests, coverage_map, source_map)
+      client = DaemonClient.new(boot: boot_config(config, abs_tests),
+                                app_root: config.project_root).start
+      results = []
+      begin
+        jobs.each_with_index do |job, i|
+          r = job_result(job, i, client, 0, config, coverage_map, abs_tests, source_map)
+          results << r
+          break if config.fail_fast && r.survived?
+        end
+      ensure
+        client.quit
+      end
+      results
+    end
+
+    # Parallel path: N daemon handles, each pinned to its own worker slot (own DB).
+    # A shared queue of job indices feeds N tool-side threads; results are placed by
+    # input index so the verdict set matches serial. Callers must not pass fail_fast
+    # here ({execute} forces serial for fail-fast).
+    #
+    # @return [Array<Mutineer::Result>] completed results in input order.
+    def self.run_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
+      results = Array.new(jobs.size)
+      queue   = Queue.new
+      jobs.each_index { |i| queue << i }
+
+      clients = Array.new(worker_count) do
+        DaemonClient.new(boot: boot_config(config, abs_tests),
+                         app_root: config.project_root).start
+      end
+
+      clients.each_with_index.map do |client, worker|
+        Thread.new do
+          loop do
+            i = begin
+              queue.pop(true)
+            rescue ThreadError
+              break
+            end
+            results[i] = job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
+          end
+        ensure
+          client.quit
+        end
+      end.each(&:join)
+
+      results.compact
+    end
+
+    # Build the payload for one job, run it on the given daemon/worker, and attach
+    # the subject/mutation/id. Shared body of both daemon paths.
+    #
+    # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
+    # @param req_id [Integer] request id (echoed back for IPC ordering safety).
+    # @param client [Mutineer::DaemonClient] the daemon handle to run on.
+    # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
+    # @return [Mutineer::Result] the decorated result.
+    def self.job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
+      subject, mutation, id = job
+      source  = source_map[subject.file]
+      mutated = mutation.apply(source)
+      # Skip an invalid mutant tool-side: never ship a payload that would fail to
+      # load and read as a false `killed`.
+      # Narrow to covering tests (shared with the in-process path via
+      # Runner.coverage_selection, so scores match). :verdict = no_coverage/uncapturable,
+      # no fork. No map (build failed) → run the full --test set (fallback, not
+      # narrowed).
+      sel = coverage_map && Runner.coverage_selection(subject.file, mutation, subject, source, coverage_map)
+      r =
+        if Parser.parse_string(mutated).errors.any?
+          Result.skipped
+        elsif sel && sel[0] == :verdict
+          sel[1]
+        else
+          verdict = client.request(
+            id: req_id, worker: worker, timeout: config.daemon_timeout || TIMEOUT,
+            payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
+            tests: sel ? sel[1] : abs_tests
+          )
+          result_for(verdict)
+        end
+      r.with(subject: subject, mutation: mutation, id: id)
+    end
+
+    # The boot config the daemon needs to boot the app once: where to boot, the test
+    # load roots (so `require "test_helper"` resolves in every fork), framework, and
+    # whether this is Rails.
+    #
+    # @param config [Mutineer::Config] the run config.
+    # @param abs_tests [Array<String>] absolute --test paths.
+    # @param coverage [Boolean] whether this daemon builds the coverage map.
+    # @return [Hash] the boot config shipped to the daemon.
+    def self.boot_config(config, abs_tests, coverage: false)
+      {
+        project_root: config.project_root,
+        boot: File.expand_path(config.boot || "config/environment", config.project_root),
+        load_paths: Runner.test_load_roots(abs_tests),
+        source_dirs: Runner.source_dirs(config), # so the daemon can sweep orphan mutant temps
+        framework: config.framework,
+        rails: config.rails,
+        # Schema for per-worker DB isolation. Sent when present; the daemon
+        # skips worker-DB schema loading if the path is absent (e.g. structure.sql apps).
+        schema: schema_path(config),
+        # Coverage narrowing. Only the short-lived map-building daemon starts
+        # Coverage (before boot); worker daemons boot with it OFF (no wasted
+        # instrumentation/memory across every mutant fork). `sources`/`tests` are the
+        # map-build inputs.
+        coverage: coverage,
+        sources: config.sources.map { |s| File.expand_path(s, config.project_root) },
+        tests: abs_tests
+      }
+    end
+
+    # Absolute path to the app's `db/schema.rb` if it exists, else nil. Used by the
+    # daemon to schema-load each fork's isolated worker database. Only `schema.rb`
+    # is supported this pass; `structure.sql` apps get nil and fall back to
+    # whatever the worker DB already holds.
+    #
+    # @param config [Mutineer::Config] the run config.
+    # @return [String, nil] absolute schema path or nil.
+    def self.schema_path(config)
+      path = File.expand_path("db/schema.rb", config.project_root)
+      File.exist?(path) ? path : nil
+    end
+
+    # Map a daemon verdict string to a Result. The daemon reports the four
+    # run-time states it can decide; pre-fork states (skipped/no_coverage/…) are
+    # resolved tool-side before a request is ever sent.
+    #
+    # @param verdict [String] the daemon's verdict word.
+    # @return [Mutineer::Result] the matching result.
+    def self.result_for(verdict)
+      case verdict
+      when "survived" then Result.survived
+      when "killed"   then Result.killed
+      when "timeout"  then Result.timeout
+      else Result.error("daemon verdict: #{verdict}")
+      end
+    end
+  end
+end

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -141,10 +141,12 @@ module Mutineer
     # Parallel path: N daemon handles, each pinned to its own worker slot (own DB).
     # A shared queue of job indices feeds N tool-side threads; results are placed by
     # input index so the verdict set matches serial. Callers must not pass fail_fast
-    # here ({execute} forces serial for fail-fast).
+    # here ({execute} forces serial for fail-fast). A raise inside a worker is
+    # recorded as {Result.error} for that slot (same shape as {WorkerPool}): never
+    # drop the mutant via compact, or the score silently under-counts.
     #
     # @api private
-    # @return [Array<Mutineer::Result>] completed results in input order.
+    # @return [Array<Mutineer::Result>] one result per input job, in input order.
     def self.run_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
       results = Array.new(jobs.size)
       queue   = Queue.new
@@ -163,14 +165,29 @@ module Mutineer
             rescue ThreadError
               break
             end
-            results[i] = job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
+            subject, mutation, id = jobs[i]
+            results[i] =
+              begin
+                job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
+              rescue StandardError => e
+                Result.error("daemon worker crashed: #{e.class}: #{e.message}")
+                  .with(subject: subject, mutation: mutation, id: id)
+              end
           end
         ensure
           client.quit
         end
       end.each(&:join)
 
-      results.compact
+      # Every input slot must stay a Result. A thread that dies before writing
+      # still leaves a hole; map those rather than compacting them away.
+      results.each_with_index.map do |r, i|
+        next r if r
+
+        subject, mutation, id = jobs[i]
+        Result.error("daemon worker produced no result")
+          .with(subject: subject, mutation: mutation, id: id)
+      end
     end
 
     # Build the payload for one job, run it on the given daemon/worker, and attach

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -141,12 +141,10 @@ module Mutineer
     # Parallel path: N daemon handles, each pinned to its own worker slot (own DB).
     # A shared queue of job indices feeds N tool-side threads; results are placed by
     # input index so the verdict set matches serial. Callers must not pass fail_fast
-    # here ({execute} forces serial for fail-fast). Per-mutant crashes are classified
-    # in {job_result}, shared with the serial path; a {DaemonBootError} ends the run
-    # here rather than scoring the remainder against a daemon that has given up.
+    # here ({execute} forces serial for fail-fast).
     #
     # @api private
-    # @return [Array<Mutineer::Result>] one result per input job, in input order.
+    # @return [Array<Mutineer::Result>] completed results in input order.
     def self.run_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
       results = Array.new(jobs.size)
       queue   = Queue.new
@@ -167,39 +165,22 @@ module Mutineer
             end
             results[i] = job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
           end
-        rescue DaemonBootError
-          # The daemon gave up for good. Stop feeding the other workers rather
-          # than letting them score the rest of the run against a dead client;
-          # Thread#join re-raises this and ends the run.
-          queue.clear
-          raise
         ensure
           client.quit
         end
       end.each(&:join)
 
-      # Every job was popped by some worker and every pop assigns, so no slot can
-      # be nil here: an escaping exception aborts the run via join instead.
-      results
+      results.compact
     end
 
     # Build the payload for one job, run it on the given daemon/worker, and attach
-    # the subject/mutation/id. Shared body of both daemon paths, so `--jobs 1` and
-    # `--jobs N` classify an identical fault identically.
-    #
-    # Error model, in one place because both paths call this: a crash while running
-    # ONE mutant is that mutant's `error` verdict and the run continues, matching
-    # {WorkerPool} and the daemon's own in-band crash reply. {DaemonBootError} is
-    # different — it is DaemonClient's signal that the daemon is gone for good after
-    # MAX_RESTARTS — so it propagates and ends the run. Scoring the remaining mutants
-    # against a dead daemon would print a score built on a fraction of the work.
+    # the subject/mutation/id. Shared body of both daemon paths.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
     # @param client [Mutineer::DaemonClient] the daemon handle to run on.
     # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
     # @api private
-    # @raise [Mutineer::DaemonBootError] when the daemon has given up; ends the run.
     # @return [Mutineer::Result] the decorated result.
     def self.job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
       subject, mutation, id = job
@@ -226,11 +207,6 @@ module Mutineer
           result_for(verdict)
         end
       r.with(subject: subject, mutation: mutation, id: id)
-    rescue DaemonBootError
-      raise
-    rescue StandardError => e
-      Result.error("daemon worker crashed: #{e.class}: #{e.message}")
-        .with(subject: subject, mutation: mutation, id: id)
     end
 
     # The boot config the daemon needs to boot the app once: where to boot, the test

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -8,8 +8,9 @@ require_relative "daemon_client"
 # runner.rb requires this file, so declaring the reverse edge makes Ruby print
 # "circular require considered harmful" out of a shipped library on every -w load.
 # Runner is always loaded first in practice (lib/mutineer.rb and cli.rb both require
-# it, and requiring it loads this file). Breaking the dependency for real means
-# lifting the shared job vocabulary out of Runner — tracked separately.
+# it, and requiring it loads this file). Require this file on its own and Runner is
+# undefined, so {DaemonBackend.execute} raises NameError on its first line. Breaking
+# the dependency for real means lifting the shared job vocabulary out of Runner (#75).
 
 module Mutineer
   # Daemon execution backend. Boots the app ONCE in a persistent subprocess under
@@ -119,6 +120,7 @@ module Mutineer
     # Serial path: one daemon (worker 0), one mutant at a time. Honors --fail-fast
     # (stop at the first survivor).
     #
+    # @api private
     # @return [Array<Mutineer::Result>] results in input order.
     def self.run_serial(jobs, config, abs_tests, coverage_map, source_map)
       client = DaemonClient.new(boot: boot_config(config, abs_tests),
@@ -141,6 +143,7 @@ module Mutineer
     # input index so the verdict set matches serial. Callers must not pass fail_fast
     # here ({execute} forces serial for fail-fast).
     #
+    # @api private
     # @return [Array<Mutineer::Result>] completed results in input order.
     def self.run_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
       results = Array.new(jobs.size)
@@ -177,6 +180,7 @@ module Mutineer
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
     # @param client [Mutineer::DaemonClient] the daemon handle to run on.
     # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
+    # @api private
     # @return [Mutineer::Result] the decorated result.
     def self.job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
       subject, mutation, id = job
@@ -240,6 +244,7 @@ module Mutineer
     # whatever the worker DB already holds.
     #
     # @param config [Mutineer::Config] the run config.
+    # @api private
     # @return [String, nil] absolute schema path or nil.
     def self.schema_path(config)
       path = File.expand_path("db/schema.rb", config.project_root)
@@ -251,6 +256,7 @@ module Mutineer
     # resolved tool-side before a request is ever sent.
     #
     # @param verdict [String] the daemon's verdict word.
+    # @api private
     # @return [Mutineer::Result] the matching result.
     def self.result_for(verdict)
       case verdict
@@ -262,8 +268,9 @@ module Mutineer
     end
 
     # The module's contract is {execute} (the backend entry point) plus the two the
-    # suite drives directly, {build_coverage_map} and {boot_config}. Everything else
-    # is daemon-pipeline internals with no caller outside this file.
+    # tests drive directly: {boot_config} from the zero-dep suite and
+    # {build_coverage_map} from the daemon suite. Everything else is daemon-pipeline
+    # internals with no caller outside this file.
     private_class_method :run_serial, :run_parallel, :job_result, :schema_path, :result_for
   end
 end

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -4,6 +4,10 @@ require_relative "parser"
 require_relative "result"
 require_relative "coverage_map"
 require_relative "daemon_client"
+# Runner owns the shared invariants this backend calls (job collection, --since,
+# coverage selection, path helpers). runner.rb requires this file in turn; the
+# cycle is safe because neither file names the other's constants at load time.
+require_relative "runner"
 
 module Mutineer
   # Daemon execution backend. Boots the app ONCE in a persistent subprocess under

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -21,11 +21,18 @@ module Mutineer
   # Job collection, `--since` filtering and coverage selection stay on {Runner} and
   # are called from here, so the daemon path can never drift from the in-process
   # path on which mutants run or which tests narrow a mutant (score parity).
+  #
+  # That call-back is the one way this module is NOT shaped like {ExternalBackend}:
+  # that one is a leaf {Runner} calls into, while this one owns its orchestration and
+  # reaches back for the shared job vocabulary. The dependency runs backend -> shared
+  # machinery, never backend -> backend, and {Runner} keeps the external orchestration.
   module DaemonBackend
-    # Default per-mutant timeout on the daemon path (seconds). Coverage narrowing
-    # usually keeps each job short; this still covers a slow suite or full-suite
-    # fallback when the coverage map is unavailable.
-    TIMEOUT = 60
+    # Default per-mutant timeout on the daemon path (seconds), overridden by
+    # config.daemon_timeout. Coverage narrowing usually keeps each job short; this
+    # still covers a slow suite or full-suite fallback when the map is unavailable.
+    # Named like its in-process counterpart {Isolation::DEFAULT_TIMEOUT}, not like
+    # {ExternalBackend::SMOKE_TIMEOUT}, which bounds a different thing.
+    DEFAULT_TIMEOUT = 60
 
     # Full daemon run: collect jobs, build the coverage map once, then execute
     # serially or across N worker daemons. Fail-fast forces serial so the survivor
@@ -187,7 +194,7 @@ module Mutineer
           sel[1]
         else
           verdict = client.request(
-            id: req_id, worker: worker, timeout: config.daemon_timeout || TIMEOUT,
+            id: req_id, worker: worker, timeout: config.daemon_timeout || DEFAULT_TIMEOUT,
             payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
             tests: sel ? sel[1] : abs_tests
           )
@@ -251,5 +258,10 @@ module Mutineer
       else Result.error("daemon verdict: #{verdict}")
       end
     end
+
+    # The module's contract is {execute} (the backend entry point) plus the two the
+    # suite drives directly, {build_coverage_map} and {boot_config}. Everything else
+    # is daemon-pipeline internals with no caller outside this file.
+    private_class_method :run_serial, :run_parallel, :job_result, :schema_path, :result_for
   end
 end

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -4,13 +4,10 @@ require_relative "parser"
 require_relative "result"
 require_relative "coverage_map"
 require_relative "daemon_client"
-# Deliberately NOT require_relative "runner", even though this module calls it:
-# runner.rb requires this file, so declaring the reverse edge makes Ruby print
-# "circular require considered harmful" out of a shipped library on every -w load.
-# Runner is always loaded first in practice (lib/mutineer.rb and cli.rb both require
-# it, and requiring it loads this file). Require this file on its own and Runner is
-# undefined, so {DaemonBackend.execute} raises NameError on its first line. Breaking
-# the dependency for real means lifting the shared job vocabulary out of Runner (#75).
+# No require_relative "runner" on purpose: runner.rb requires this file, and the
+# reverse edge makes Ruby warn "circular require considered harmful" on every -w
+# load. Runner is loaded first on every real path; requiring this file alone leaves
+# it undefined. Rationale and the real fix: #75.
 
 module Mutineer
   # Daemon execution backend. Boots the app ONCE in a persistent subprocess under
@@ -25,10 +22,8 @@ module Mutineer
   # are called from here, so the daemon path can never drift from the in-process
   # path on which mutants run or which tests narrow a mutant (score parity).
   #
-  # That call-back is the one way this module is NOT shaped like {ExternalBackend}:
-  # that one is a leaf {Runner} calls into, while this one owns its orchestration and
-  # reaches back for the shared job vocabulary. The dependency runs backend -> shared
-  # machinery, never backend -> backend, and {Runner} keeps the external orchestration.
+  # Unlike {ExternalBackend}, which is a leaf {Runner} calls into, this module owns
+  # its orchestration and calls back for that shared vocabulary.
   module DaemonBackend
     # Default per-mutant timeout on the daemon path (seconds), overridden by
     # config.daemon_timeout. Coverage narrowing usually keeps each job short; this

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -4,10 +4,12 @@ require_relative "parser"
 require_relative "result"
 require_relative "coverage_map"
 require_relative "daemon_client"
-# Runner owns the shared invariants this backend calls (job collection, --since,
-# coverage selection, path helpers). runner.rb requires this file in turn; the
-# cycle is safe because neither file names the other's constants at load time.
-require_relative "runner"
+# Deliberately NOT require_relative "runner", even though this module calls it:
+# runner.rb requires this file, so declaring the reverse edge makes Ruby print
+# "circular require considered harmful" out of a shipped library on every -w load.
+# Runner is always loaded first in practice (lib/mutineer.rb and cli.rb both require
+# it, and requiring it loads this file). Breaking the dependency for real means
+# lifting the shared job vocabulary out of Runner — tracked separately.
 
 module Mutineer
   # Daemon execution backend. Boots the app ONCE in a persistent subprocess under

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -141,9 +141,9 @@ module Mutineer
     # Parallel path: N daemon handles, each pinned to its own worker slot (own DB).
     # A shared queue of job indices feeds N tool-side threads; results are placed by
     # input index so the verdict set matches serial. Callers must not pass fail_fast
-    # here ({execute} forces serial for fail-fast). A raise inside a worker is
-    # recorded as {Result.error} for that slot (same shape as {WorkerPool}): never
-    # drop the mutant via compact, or the score silently under-counts.
+    # here ({execute} forces serial for fail-fast). Per-mutant crashes are classified
+    # in {job_result}, shared with the serial path; a {DaemonBootError} ends the run
+    # here rather than scoring the remainder against a daemon that has given up.
     #
     # @api private
     # @return [Array<Mutineer::Result>] one result per input job, in input order.
@@ -165,39 +165,41 @@ module Mutineer
             rescue ThreadError
               break
             end
-            subject, mutation, id = jobs[i]
-            results[i] =
-              begin
-                job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
-              rescue StandardError => e
-                Result.error("daemon worker crashed: #{e.class}: #{e.message}")
-                  .with(subject: subject, mutation: mutation, id: id)
-              end
+            results[i] = job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
           end
+        rescue DaemonBootError
+          # The daemon gave up for good. Stop feeding the other workers rather
+          # than letting them score the rest of the run against a dead client;
+          # Thread#join re-raises this and ends the run.
+          queue.clear
+          raise
         ensure
           client.quit
         end
       end.each(&:join)
 
-      # Every input slot must stay a Result. A thread that dies before writing
-      # still leaves a hole; map those rather than compacting them away.
-      results.each_with_index.map do |r, i|
-        next r if r
-
-        subject, mutation, id = jobs[i]
-        Result.error("daemon worker produced no result")
-          .with(subject: subject, mutation: mutation, id: id)
-      end
+      # Every job was popped by some worker and every pop assigns, so no slot can
+      # be nil here: an escaping exception aborts the run via join instead.
+      results
     end
 
     # Build the payload for one job, run it on the given daemon/worker, and attach
-    # the subject/mutation/id. Shared body of both daemon paths.
+    # the subject/mutation/id. Shared body of both daemon paths, so `--jobs 1` and
+    # `--jobs N` classify an identical fault identically.
+    #
+    # Error model, in one place because both paths call this: a crash while running
+    # ONE mutant is that mutant's `error` verdict and the run continues, matching
+    # {WorkerPool} and the daemon's own in-band crash reply. {DaemonBootError} is
+    # different — it is DaemonClient's signal that the daemon is gone for good after
+    # MAX_RESTARTS — so it propagates and ends the run. Scoring the remaining mutants
+    # against a dead daemon would print a score built on a fraction of the work.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
     # @param client [Mutineer::DaemonClient] the daemon handle to run on.
     # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
     # @api private
+    # @raise [Mutineer::DaemonBootError] when the daemon has given up; ends the run.
     # @return [Mutineer::Result] the decorated result.
     def self.job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
       subject, mutation, id = job
@@ -224,6 +226,11 @@ module Mutineer
           result_for(verdict)
         end
       r.with(subject: subject, mutation: mutation, id: id)
+    rescue DaemonBootError
+      raise
+    rescue StandardError => e
+      Result.error("daemon worker crashed: #{e.class}: #{e.message}")
+        .with(subject: subject, mutation: mutation, id: id)
     end
 
     # The boot config the daemon needs to boot the app once: where to boot, the test

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -142,7 +142,7 @@ module Mutineer
     # removed from the killed+survived denominator so a strong file reaches 100%.
     # The stable id is computed per subject (occurrence needs the full list) and
     # carried on every job so the parent can reattach it after the run. Shared by
-    # the in-process and external backends so job selection can never drift.
+    # the in-process, external, and daemon backends so job selection can never drift.
     #
     # @return [Array(Array, Array<Result>, Hash<String,String>)] jobs, ignored, source_map.
     def self.collect_jobs(config, operator_classes)

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -341,10 +341,10 @@ module Mutineer
     end
 
     # The unique absolute directories holding the sources. Sweep target for both
-    # orphan mechanisms (in-process mutant tempfiles and external backup files).
-    # Shared so the path-expansion rule cannot drift between the two paths.
+    # orphan mechanisms (in-process mutant tempfiles and external backup files),
+    # and shipped to the daemon via {DaemonBackend.boot_config} so it can sweep too.
+    # Shared so the path-expansion rule cannot drift between the paths.
     #
-    # @api private
     # @param config [Mutineer::Config] run configuration.
     # @return [Array<String>] unique absolute source directories.
     def self.source_dirs(config)

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -13,7 +13,7 @@ require_relative "worker_pool"
 require_relative "mutant_id"
 require_relative "file_swap"
 require_relative "external_backend"
-require_relative "daemon_client"
+require_relative "daemon_backend"
 require "set"
 
 module Mutineer
@@ -49,7 +49,7 @@ module Mutineer
       # Daemon backend: boot the app ONCE in a persistent subprocess under the
       # app's bundle and fork per mutant. Tool-side we only discover jobs + build
       # payloads (Prism), so branch before any in-process boot.
-      return execute_daemon(config, operator_classes) if config.daemon
+      return DaemonBackend.execute(config, operator_classes) if config.daemon
 
       # Boot mode: require the boot file ONCE so the app env (e.g. Rails) is booted
       # in the parent and inherited by every fork. Do NOT manually require the
@@ -232,176 +232,6 @@ module Mutineer
       end
     end
 
-    # Daemon backend: boot the app once in a persistent subprocess and fork per
-    # mutant. Tool-side we build the ready-to-`load` payload (whole-file reload by
-    # default) and ship it; the daemon needs no Prism/mutineer. Coverage is built
-    # once via a short-lived daemon so each mutant runs only its covering tests.
-    # When jobs > 1, each worker uses its own database (SQLite). Fail-fast forces
-    # serial so the survivor set matches jobs 1.
-    #
-    # @return [Array(Mutineer::AggregateResult, Hash<String,String>)] aggregate and source map.
-    def self.execute_daemon(config, operator_classes)
-      jobs, ignored_results, source_map = collect_jobs(config, operator_classes)
-      jobs = filter_since(jobs, source_map, config) if config.since
-      abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
-
-      # Build the coverage map once (app-side). nil when the build fails: runners
-      # fall back to the full --test set (and emit a stderr warning) rather than
-      # mis-scoring everything as no_coverage.
-      coverage_map = daemon_coverage_map(config, abs_tests)
-
-      # Worker count = resolved --jobs, capped at the job count (no idle daemons).
-      # >1 → N concurrent daemon handles, each on its OWN worker DB (N-handles, the
-      # spike-proven shape). 1 → the serial single-daemon path. --fail-fast forces
-      # serial: parallel's stop flag fires on the first survivor by WALL-CLOCK, not
-      # input index, so the verdict set would diverge from serial (a different,
-      # non-deterministic survivor set/score). The "identical to --jobs 1" guarantee
-      # below only holds when fail-fast cannot race.
-      worker_count = [config.jobs || 1, 1].max
-      worker_count = 1 if config.fail_fast
-      worker_count = [worker_count, jobs.size].min if jobs.size.positive?
-
-      results =
-        if worker_count > 1
-          run_daemon_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
-        else
-          run_daemon_serial(jobs, config, abs_tests, coverage_map, source_map)
-        end
-
-      [AggregateResult.new(results + ignored_results), source_map]
-    end
-
-    # Build the coverage map via a short-lived daemon (boots the app once, captures
-    # per-test coverage app-side, ships the map back). Returns a query-only
-    # CoverageMap, or nil when the build fails / returns empty. Callers then run the
-    # full --test set. Coverage-build IPC has no wall-clock (same limitation as
-    # in-process build_via_fork). A normal nonempty map scores like in-process;
-    # nil falls back to the full suite (more testing, not comparable).
-    #
-    # @param config [Mutineer::Config] the run config.
-    # @param abs_tests [Array<String>] absolute --test paths.
-    # @return [Mutineer::CoverageMap, nil]
-    def self.daemon_coverage_map(config, abs_tests)
-      client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests, coverage: true),
-                                app_root: config.project_root).start
-      data = begin
-        client.coverage
-      ensure
-        client.quit
-      end
-      unless data && !(data["map"] || {}).empty?
-        reason = data.is_a?(Hash) && data["error"] ? data["error"] : "empty map"
-        warn_daemon_coverage_fallback(reason)
-        return nil
-      end
-
-      CoverageMap.from_data(map: data["map"], failed_test_files: data["failed_test_files"] || [],
-                            project_root: config.project_root)
-    rescue DaemonBootError => e
-      warn_daemon_coverage_fallback("#{e.class}: #{e.message}")
-      nil
-    end
-
-    # Stderr note when daemon coverage is unavailable (full --test set per mutant).
-    #
-    # @api private
-    # @param reason [String] short cause (boot error message, empty map, …).
-    # @return [void]
-    def self.warn_daemon_coverage_fallback(reason = "unknown")
-      warn "[mutineer] daemon coverage map unavailable (#{reason}); running every " \
-           "mutant against the full --test set (score not comparable to an in-process run)."
-    end
-    private_class_method :warn_daemon_coverage_fallback
-
-    # Serial daemon path: one daemon (worker 0), one mutant at a time. Honors
-    # --fail-fast (stop at the first survivor).
-    #
-    # @return [Array<Mutineer::Result>] results in input order.
-    def self.run_daemon_serial(jobs, config, abs_tests, coverage_map, source_map)
-      client = DaemonClient.new(boot: daemon_boot_config(config, abs_tests),
-                                app_root: config.project_root).start
-      results = []
-      begin
-        jobs.each_with_index do |job, i|
-          r = daemon_job_result(job, i, client, 0, config, coverage_map, abs_tests, source_map)
-          results << r
-          break if config.fail_fast && r.survived?
-        end
-      ensure
-        client.quit
-      end
-      results
-    end
-
-    # Parallel daemon path: N daemon handles, each pinned to its own worker slot
-    # (own DB). A shared queue of job indices feeds N tool-side threads; results
-    # are placed by input index so the verdict set matches serial. Callers must
-    # not pass fail_fast here (execute_daemon forces serial for fail-fast).
-    #
-    # @return [Array<Mutineer::Result>] completed results in input order.
-    def self.run_daemon_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
-      results = Array.new(jobs.size)
-      queue   = Queue.new
-      jobs.each_index { |i| queue << i }
-
-      clients = Array.new(worker_count) do
-        DaemonClient.new(boot: daemon_boot_config(config, abs_tests),
-                         app_root: config.project_root).start
-      end
-
-      clients.each_with_index.map do |client, worker|
-        Thread.new do
-          loop do
-            i = begin
-              queue.pop(true)
-            rescue ThreadError
-              break
-            end
-            results[i] = daemon_job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
-          end
-        ensure
-          client.quit
-        end
-      end.each(&:join)
-
-      results.compact
-    end
-
-    # Build the payload for one job, run it on the given daemon/worker, and attach
-    # the subject/mutation/id. Shared body of both daemon paths.
-    #
-    # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
-    # @param req_id [Integer] request id (echoed back for IPC ordering safety).
-    # @param client [Mutineer::DaemonClient] the daemon handle to run on.
-    # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
-    # @return [Mutineer::Result] the decorated result.
-    def self.daemon_job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
-      subject, mutation, id = job
-      source  = source_map[subject.file]
-      mutated = mutation.apply(source)
-      # Skip an invalid mutant tool-side: never ship a payload that would fail to
-      # load and read as a false `killed`.
-      # Narrow to covering tests (shared with the in-process path via
-      # coverage_selection, so scores match). :verdict = no_coverage/uncapturable,
-      # no fork. No map (build failed) → run the full --test set (fallback, not
-      # narrowed).
-      sel = coverage_map && coverage_selection(subject.file, mutation, subject, source, coverage_map)
-      r =
-        if Parser.parse_string(mutated).errors.any?
-          Result.skipped
-        elsif sel && sel[0] == :verdict
-          sel[1]
-        else
-          verdict = client.request(
-            id: req_id, worker: worker, timeout: config.daemon_timeout || DAEMON_TIMEOUT,
-            payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
-            tests: sel ? sel[1] : abs_tests
-          )
-          daemon_result(verdict)
-        end
-      r.with(subject: subject, mutation: mutation, id: id)
-    end
-
     # Coverage-based test selection, shared by the in-process ({run}) and daemon
     # paths so both narrow identically (score parity). Returns
     # `[:run, abs_test_paths]` when some test covers the mutant's line, or
@@ -431,59 +261,6 @@ module Mutineer
       end
 
       [:run, chosen.map { |t| File.expand_path(t, coverage_map.project_root) }]
-    end
-
-    # Default per-mutant timeout on the daemon path (seconds). Coverage narrowing
-    # usually keeps each job short; this still covers a slow suite or full-suite
-    # fallback when the coverage map is unavailable.
-    DAEMON_TIMEOUT = 60
-
-    # The boot config the daemon needs to boot the app once: where to boot, the test
-    # load roots (so `require "test_helper"` resolves in every fork), framework, and
-    # whether this is Rails.
-    def self.daemon_boot_config(config, abs_tests, coverage: false)
-      {
-        project_root: config.project_root,
-        boot: File.expand_path(config.boot || "config/environment", config.project_root),
-        load_paths: test_load_roots(abs_tests),
-        source_dirs: source_dirs(config), # so the daemon can sweep orphan mutant temps
-        framework: config.framework,
-        rails: config.rails,
-        # Schema for per-worker DB isolation. Sent when present; the daemon
-        # skips worker-DB schema loading if the path is absent (e.g. structure.sql apps).
-        schema: daemon_schema_path(config),
-        # Coverage narrowing. Only the short-lived map-building daemon starts
-        # Coverage (before boot); worker daemons boot with it OFF (no wasted
-        # instrumentation/memory across every mutant fork). `sources`/`tests` are the
-        # map-build inputs.
-        coverage: coverage,
-        sources: config.sources.map { |s| File.expand_path(s, config.project_root) },
-        tests: abs_tests
-      }
-    end
-
-    # Absolute path to the app's `db/schema.rb` if it exists, else nil. Used by the
-    # daemon to schema-load each fork's isolated worker database. Only `schema.rb`
-    # is supported this pass; `structure.sql` apps get nil and fall back to
-    # whatever the worker DB already holds.
-    #
-    # @param config [Mutineer::Config] the run config.
-    # @return [String, nil] absolute schema path or nil.
-    def self.daemon_schema_path(config)
-      path = File.expand_path("db/schema.rb", config.project_root)
-      File.exist?(path) ? path : nil
-    end
-
-    # Map a daemon verdict string to a Result. The daemon reports the four
-    # run-time states it can decide; pre-fork states (skipped/no_coverage/…) are
-    # resolved tool-side before a request is ever sent.
-    def self.daemon_result(verdict)
-      case verdict
-      when "survived" then Result.survived
-      when "killed"   then Result.killed
-      when "timeout"  then Result.timeout
-      else Result.error("daemon verdict: #{verdict}")
-      end
     end
 
     # Scan a source once into { line_number => :all | Set[operator_syms] } from

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -25,17 +25,16 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
-  # runner.rb and daemon_backend.rb require each other. The cycle is safe only while
-  # neither file names the other's constants at load time, and every other entry point
-  # loads runner.rb first, so nothing else exercises this order. Spawn a child to prove
-  # the promise instead of asserting it in a comment.
-  def test_daemon_backend_loads_standalone_without_runner_first
-    script = 'require "mutineer/daemon_backend"; ' \
-             'print [Mutineer::DaemonBackend::DEFAULT_TIMEOUT, Mutineer::Runner.name].inspect'
-    out = IO.popen([RbConfig.ruby, "-I#{File.expand_path("../lib", __dir__)}", "-e", script], err: %i[child out], &:read)
+  # daemon_backend.rb calls Runner but must never require it: runner.rb requires
+  # daemon_backend, so the reverse edge makes Ruby print "circular require considered
+  # harmful" into the process of anyone who loads Mutineer with warnings on. Both Rake
+  # tasks set warning = false, so only a child process with -w can see a regression here.
+  def test_loading_the_gem_emits_no_circular_require_warning
+    out = IO.popen([RbConfig.ruby, "-w", "-I#{File.expand_path("../lib", __dir__)}",
+                    "-e", 'require "mutineer"'], err: %i[child out], &:read)
 
-    assert_equal '[60, "Mutineer::Runner"]', out.strip,
-                 "requiring mutineer/daemon_backend first must still define both modules"
+    refute_match(/circular require/, out,
+                 "a require cycle between runner.rb and daemon_backend.rb warns on every -w load")
   end
 
   # Exercises the shared helpers for real rather than by respond_to? alone:

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+require "mutineer/config"
+require "mutineer/daemon_backend"
+
+# #58: DaemonBackend reaches back into Runner for the invariants both backends must
+# share (job collection, --since, coverage selection, path helpers). The split turned
+# those intra-class calls into a cross-module contract, and every test that exercises
+# it lives in DAEMON_TESTS — excluded from the zero-dep suite. So renaming or
+# privatising one of the five would leave `rake test`, the load smoke and yard:strict
+# all green while the daemon path raises at runtime. These checks are Rails-free and
+# daemon-free on purpose: they run in the default suite and fail the moment the
+# contract moves.
+class DaemonBackendContractTest < Minitest::Test
+  # The Runner methods DaemonBackend calls across the module boundary.
+  SHARED = %i[collect_jobs filter_since coverage_selection test_load_roots source_dirs].freeze
+
+  def test_runner_publicly_answers_every_shared_invariant
+    SHARED.each do |m|
+      assert_respond_to Mutineer::Runner, m,
+                        "DaemonBackend calls Runner.#{m}; making it private or renaming it " \
+                        "breaks the daemon backend without failing the zero-dep suite"
+    end
+  end
+
+  # Exercises the shared helpers for real rather than by respond_to? alone:
+  # boot_config routes through Runner.test_load_roots and Runner.source_dirs.
+  def test_boot_config_resolves_load_roots_and_source_dirs
+    Dir.mktmpdir("mutineer-contract") do |root|
+      FileUtils.mkdir_p(File.join(root, "app/models"))
+      FileUtils.mkdir_p(File.join(root, "test/models"))
+      source = File.join(root, "app/models/order.rb")
+      test   = File.join(root, "test/models/order_test.rb")
+      File.binwrite(source, "class Order; end\n")
+      File.binwrite(test, "require \"test_helper\"\n")
+      File.binwrite(File.join(root, "test/test_helper.rb"), "\n")
+
+      config = Mutineer::Config.new(sources: [source], tests: [test], project_root: root,
+                                    framework: "minitest", rails: true)
+      boot = Mutineer::DaemonBackend.boot_config(config, [test])
+
+      assert_includes boot[:load_paths], File.join(root, "test"),
+                      "the test_helper root must reach the daemon so `require \"test_helper\"` resolves in each fork"
+      assert_equal [File.join(root, "app/models")], boot[:source_dirs]
+      assert_nil boot[:schema], "no db/schema.rb in this app, so the daemon skips worker-DB schema loading"
+      assert boot[:rails]
+      refute boot[:coverage], "worker daemons boot with Coverage off; only the map-building daemon enables it"
+    end
+  end
+end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -28,6 +28,20 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
+  # SHARED is the contract. Drift either way (a new Runner. call in the backend, or
+  # a stale symbol left in the list) must fail here, not only when something privatises.
+  def test_shared_list_matches_runner_calls_in_daemon_backend_source
+    src = File.read(File.expand_path("../lib/mutineer/daemon_backend.rb", __dir__))
+    called = src.lines
+                .reject { |l| l.lstrip.start_with?("#") }
+                .flat_map { |l| l.scan(/Runner\.(\w+)/).flatten }
+                .uniq
+                .map(&:to_sym)
+                .sort
+    assert_equal SHARED.sort, called,
+                 "SHARED must list exactly the Runner methods daemon_backend.rb calls"
+  end
+
   # daemon_backend.rb calls Runner but must never require it: runner.rb requires
   # daemon_backend, so the reverse edge makes Ruby print "circular require considered
   # harmful" into the process of anyone who loads Mutineer with warnings on. Both Rake
@@ -72,6 +86,55 @@ class DaemonBackendContractTest < Minitest::Test
       assert_nil boot[:schema], "no db/schema.rb in this app, so the daemon skips worker-DB schema loading"
       assert boot[:rails]
       refute boot[:coverage], "worker daemons boot with Coverage off; only the map-building daemon enables it"
+    end
+  end
+
+  # Parallel workers must not drop mutants on crash: a raise used to leave a nil
+  # that compact removed, so the mutant vanished from AggregateResult. Mirror
+  # WorkerPool — keep every input slot as Result.error.
+  def test_run_parallel_records_error_when_job_result_raises
+    Dir.mktmpdir("mutineer-parallel") do |root|
+      FileUtils.mkdir_p(File.join(root, "app"))
+      FileUtils.mkdir_p(File.join(root, "test"))
+      source = File.join(root, "app/order.rb")
+      test   = File.join(root, "test/order_test.rb")
+      File.binwrite(source, "class Order; end\n")
+      File.binwrite(test, "\n")
+      File.binwrite(File.join(root, "test/test_helper.rb"), "\n")
+
+      config = Mutineer::Config.new(sources: [source], tests: [test], project_root: root,
+                                    framework: "minitest")
+      subject = Object.new
+      mutation = Object.new
+      jobs = [
+        [subject, mutation, "id-0"],
+        [subject, mutation, "id-1"]
+      ]
+
+      client = Object.new
+      def client.start = self
+      def client.quit = nil
+
+      job_result = lambda do |_job, i, *_rest|
+        raise "boom" if i.zero?
+
+        Mutineer::Result.killed.with(subject: subject, mutation: mutation, id: "id-1")
+      end
+
+      results = Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+        Mutineer::DaemonBackend.stub(:job_result, job_result) do
+          Mutineer::DaemonBackend.send(
+            :run_parallel, jobs, 2, config, [test], nil, { source => "class Order; end\n" }
+          )
+        end
+      end
+
+      assert_equal 2, results.size, "every input job must keep a slot"
+      assert_predicate results[0], :error?
+      assert_match(/daemon worker crashed/, results[0].details)
+      assert_equal "id-0", results[0].id
+      assert_predicate results[1], :killed?
+      assert_equal "id-1", results[1].id
     end
   end
 end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -28,39 +28,12 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
-  # SHARED is hand-maintained, so it can drift from the real call sites: add a sixth
-  # Runner call and the tripwire above still passes while no longer covering it.
-  def test_shared_list_matches_runner_calls_in_daemon_backend_source
-    src = File.read(File.expand_path("../lib/mutineer/daemon_backend.rb", __dir__))
-    # Text scan, not a call graph. Two ways it misreads Ruby, both closed here:
-    # prose mentioning `Runner.foo` (this file is comment-heavy) would count as a
-    # call, and a wrapped `Runner\n  .foo` call would not. `#{` is interpolation,
-    # not a comment. A string literal containing the text still fools it.
-    called = src.lines
-                .map { |l| l.sub(/#(?!\{).*/, "") }
-                .join
-                .gsub(/\n\s*\./, ".")
-                .scan(/Runner\.(\w+)/)
-                .flatten
-                .uniq
-                .map(&:to_sym)
-                .sort
-
-    assert_equal SHARED.sort, called,
-                 "SHARED must list exactly the Runner methods daemon_backend.rb calls"
-  end
-
-  # daemon_backend.rb calls Runner but must never require it: runner.rb requires
-  # daemon_backend, so the reverse edge makes Ruby print "circular require considered
-  # harmful" into the process of anyone who loads Mutineer with warnings on. Both Rake
-  # tasks set warning = false, so only a child process with -w can see a regression here.
+  # A require cycle between runner.rb and daemon_backend.rb warns on every -w load,
+  # and both Rake tasks set warning = false, so only a child process can see it. The
+  # exit status and the loaded path are asserted too, or a failed load would pass this
+  # by printing no warning either.
   def test_loading_the_gem_emits_no_circular_require_warning
     lib = File.expand_path("../lib", __dir__)
-    # Report which daemon_backend.rb actually got loaded. Three ways this could pass
-    # while proving nothing, all closed below: a silent load failure prints no warning
-    # either; an installed mutineer gem would satisfy the require from somewhere else;
-    # and stderr is merged here, so a backtrace naming this file would satisfy a path
-    # check on its own. Hence the exit status AND the path.
     script = 'require "mutineer"; print $LOADED_FEATURES.grep(/daemon_backend/).first.to_s'
     out = IO.popen([RbConfig.ruby, "-w", "-I#{lib}", "-e", script], err: %i[child out], &:read)
     status = $CHILD_STATUS

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "English"
 require "tmpdir"
 require "mutineer/config"
 require "mutineer/daemon_backend"
@@ -31,12 +32,16 @@ class DaemonBackendContractTest < Minitest::Test
   # tasks set warning = false, so only a child process with -w can see a regression here.
   def test_loading_the_gem_emits_no_circular_require_warning
     lib = File.expand_path("../lib", __dir__)
-    # Report which daemon_backend.rb actually got loaded. A silent load failure prints
-    # no warning either, and an installed mutineer gem would satisfy the require from
-    # somewhere else entirely — both would leave the refute below passing vacuously.
+    # Report which daemon_backend.rb actually got loaded. Three ways this could pass
+    # while proving nothing, all closed below: a silent load failure prints no warning
+    # either; an installed mutineer gem would satisfy the require from somewhere else;
+    # and stderr is merged here, so a backtrace naming this file would satisfy a path
+    # check on its own. Hence the exit status AND the path.
     script = 'require "mutineer"; print $LOADED_FEATURES.grep(/daemon_backend/).first.to_s'
     out = IO.popen([RbConfig.ruby, "-w", "-I#{lib}", "-e", script], err: %i[child out], &:read)
+    status = $CHILD_STATUS
 
+    assert_predicate status, :success?, "the child failed to load Mutineer, so this proved nothing:\n#{out}"
     assert_includes out, File.join(lib, "mutineer/daemon_backend.rb"),
                     "the child did not load this working tree, so this proved nothing"
     refute_match(/circular require/, out,

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -32,8 +32,11 @@ class DaemonBackendContractTest < Minitest::Test
   # a stale symbol left in the list) must fail here, not only when something privatises.
   def test_shared_list_matches_runner_calls_in_daemon_backend_source
     src = File.read(File.expand_path("../lib/mutineer/daemon_backend.rb", __dir__))
+    # Text scan, not a call graph: strip whole-line AND trailing comments first, or
+    # prose mentioning `Runner.foo` (this file is comment-heavy) reads as a call and
+    # fails a test about method visibility. `#{` is interpolation, not a comment.
     called = src.lines
-                .reject { |l| l.lstrip.start_with?("#") }
+                .map { |l| l.sub(/#(?!\{).*/, "") }
                 .flat_map { |l| l.scan(/Runner\.(\w+)/).flatten }
                 .uniq
                 .map(&:to_sym)
@@ -92,49 +95,74 @@ class DaemonBackendContractTest < Minitest::Test
   # Parallel workers must not drop mutants on crash: a raise used to leave a nil
   # that compact removed, so the mutant vanished from AggregateResult. Mirror
   # WorkerPool — keep every input slot as Result.error.
-  def test_run_parallel_records_error_when_job_result_raises
-    Dir.mktmpdir("mutineer-parallel") do |root|
+  SOURCE = "class Order\n  def total(a, b)\n    a + b\n  end\nend\n"
+
+  # A real job pair, so the daemon paths run their actual code and the only stubbed
+  # thing is the daemon itself. Stubbing job_result instead would bypass the very
+  # rescue these tests exist to pin.
+  def with_jobs
+    Dir.mktmpdir("mutineer-daemon") do |root|
       FileUtils.mkdir_p(File.join(root, "app"))
-      FileUtils.mkdir_p(File.join(root, "test"))
-      source = File.join(root, "app/order.rb")
-      test   = File.join(root, "test/order_test.rb")
-      File.binwrite(source, "class Order; end\n")
-      File.binwrite(test, "\n")
-      File.binwrite(File.join(root, "test/test_helper.rb"), "\n")
+      path = File.join(root, "app/order.rb")
+      File.binwrite(path, SOURCE)
+      subject = Mutineer::Project.discover([path]).first
+      mutations = Mutineer::Mutators::Arithmetic.new.mutations_for(subject, SOURCE)
+      config = Mutineer::Config.new(sources: [path], tests: [], project_root: root, framework: "minitest")
+      jobs = [[subject, mutations.first, "id-0"], [subject, mutations.first, "id-1"]]
+      yield jobs, config, { path => SOURCE }
+    end
+  end
 
-      config = Mutineer::Config.new(sources: [source], tests: [test], project_root: root,
-                                    framework: "minitest")
-      subject = Object.new
-      mutation = Object.new
-      jobs = [
-        [subject, mutation, "id-0"],
-        [subject, mutation, "id-1"]
-      ]
-
+  # A crash running ONE mutant is that mutant's verdict, not the end of the run, and
+  # both daemon paths must agree on that or --jobs N stops matching --jobs 1.
+  def test_a_crash_running_one_mutant_is_an_error_verdict_on_both_paths
+    with_jobs do |jobs, config, source_map|
       client = Object.new
       def client.start = self
       def client.quit = nil
+      def client.request(id:, **) = id.zero? ? raise("boom") : "killed"
 
-      job_result = lambda do |_job, i, *_rest|
-        raise "boom" if i.zero?
-
-        Mutineer::Result.killed.with(subject: subject, mutation: mutation, id: "id-1")
-      end
-
-      results = Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
-        Mutineer::DaemonBackend.stub(:job_result, job_result) do
-          Mutineer::DaemonBackend.send(
-            :run_parallel, jobs, 2, config, [test], nil, { source => "class Order; end\n" }
-          )
+      %i[run_serial run_parallel].each do |path|
+        args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
+        results = Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+          Mutineer::DaemonBackend.send(path, *args)
         end
-      end
 
-      assert_equal 2, results.size, "every input job must keep a slot"
-      assert_predicate results[0], :error?
-      assert_match(/daemon worker crashed/, results[0].details)
-      assert_equal "id-0", results[0].id
-      assert_predicate results[1], :killed?
-      assert_equal "id-1", results[1].id
+        assert_equal 2, results.size, "#{path}: every input job must keep a slot"
+        assert_predicate results[0], :error?
+        assert_match(/daemon worker crashed/, results[0].details)
+        assert_equal "id-0", results[0].id
+        assert_predicate results[1], :killed?
+      end
+    end
+  end
+
+  # DaemonClient raises this only after exhausting its restart budget: the daemon is
+  # gone. Scoring the remaining mutants against it would print a score covering a
+  # fraction of the run, so the run must end instead.
+  def test_daemon_giving_up_ends_the_run_on_both_paths
+    with_jobs do |jobs, config, source_map|
+      client = Object.new
+      def client.start = self
+      def client.quit = nil
+      def client.request(**) = raise(Mutineer::DaemonBootError, "daemon crashed 3 times; aborting the run")
+
+      # The parallel path lets the abort escape a worker thread, and Ruby prints that
+      # trace by default. It is expected here, so keep it out of the suite's output.
+      reporting = Thread.report_on_exception
+      Thread.report_on_exception = false
+      begin
+        %i[run_serial run_parallel].each do |path|
+          args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
+          assert_raises(Mutineer::DaemonBootError, "#{path} must not score a run the daemon abandoned") do
+            Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+              Mutineer::DaemonBackend.send(path, *args)
+            end
+          end
+        end
+      ensure
+        Thread.report_on_exception = reporting
+      end
     end
   end
 end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -30,9 +30,15 @@ class DaemonBackendContractTest < Minitest::Test
   # harmful" into the process of anyone who loads Mutineer with warnings on. Both Rake
   # tasks set warning = false, so only a child process with -w can see a regression here.
   def test_loading_the_gem_emits_no_circular_require_warning
-    out = IO.popen([RbConfig.ruby, "-w", "-I#{File.expand_path("../lib", __dir__)}",
-                    "-e", 'require "mutineer"'], err: %i[child out], &:read)
+    lib = File.expand_path("../lib", __dir__)
+    # Report which daemon_backend.rb actually got loaded. A silent load failure prints
+    # no warning either, and an installed mutineer gem would satisfy the require from
+    # somewhere else entirely — both would leave the refute below passing vacuously.
+    script = 'require "mutineer"; print $LOADED_FEATURES.grep(/daemon_backend/).first.to_s'
+    out = IO.popen([RbConfig.ruby, "-w", "-I#{lib}", "-e", script], err: %i[child out], &:read)
 
+    assert_includes out, File.join(lib, "mutineer/daemon_backend.rb"),
+                    "the child did not load this working tree, so this proved nothing"
     refute_match(/circular require/, out,
                  "a require cycle between runner.rb and daemon_backend.rb warns on every -w load")
   end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "test_helper"
 require "English"
+require "minitest/mock"
 require "tmpdir"
 require "mutineer/config"
 require "mutineer/daemon_backend"
@@ -32,12 +33,16 @@ class DaemonBackendContractTest < Minitest::Test
   # a stale symbol left in the list) must fail here, not only when something privatises.
   def test_shared_list_matches_runner_calls_in_daemon_backend_source
     src = File.read(File.expand_path("../lib/mutineer/daemon_backend.rb", __dir__))
-    # Text scan, not a call graph: strip whole-line AND trailing comments first, or
-    # prose mentioning `Runner.foo` (this file is comment-heavy) reads as a call and
-    # fails a test about method visibility. `#{` is interpolation, not a comment.
+    # Text scan, not a call graph. Two ways it misreads Ruby, both closed here:
+    # prose mentioning `Runner.foo` (this file is comment-heavy) would count as a
+    # call, and a wrapped `Runner\n  .foo` call would not. `#{` is interpolation,
+    # not a comment. A string literal containing the text still fools it.
     called = src.lines
                 .map { |l| l.sub(/#(?!\{).*/, "") }
-                .flat_map { |l| l.scan(/Runner\.(\w+)/).flatten }
+                .join
+                .gsub(/\n\s*\./, ".")
+                .scan(/Runner\.(\w+)/)
+                .flatten
                 .uniq
                 .map(&:to_sym)
                 .sort
@@ -131,8 +136,14 @@ class DaemonBackendContractTest < Minitest::Test
         assert_equal 2, results.size, "#{path}: every input job must keep a slot"
         assert_predicate results[0], :error?
         assert_match(/daemon worker crashed/, results[0].details)
+        # subject and mutation, not just id: the reporter needs all three to place
+        # an errored mutant in its file and line, and dropping them still passes an
+        # id-only assertion.
         assert_equal "id-0", results[0].id
+        assert_equal jobs[0][0], results[0].subject
+        assert_equal jobs[0][1], results[0].mutation
         assert_predicate results[1], :killed?
+        assert_equal jobs[1][0], results[1].subject
       end
     end
   end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -25,6 +25,19 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
+  # runner.rb and daemon_backend.rb require each other. The cycle is safe only while
+  # neither file names the other's constants at load time, and every other entry point
+  # loads runner.rb first, so nothing else exercises this order. Spawn a child to prove
+  # the promise instead of asserting it in a comment.
+  def test_daemon_backend_loads_standalone_without_runner_first
+    script = 'require "mutineer/daemon_backend"; ' \
+             'print [Mutineer::DaemonBackend::DEFAULT_TIMEOUT, Mutineer::Runner.name].inspect'
+    out = IO.popen([RbConfig.ruby, "-I#{File.expand_path("../lib", __dir__)}", "-e", script], err: %i[child out], &:read)
+
+    assert_equal '[60, "Mutineer::Runner"]', out.strip,
+                 "requiring mutineer/daemon_backend first must still define both modules"
+  end
+
   # Exercises the shared helpers for real rather than by respond_to? alone:
   # boot_config routes through Runner.test_load_roots and Runner.source_dirs.
   def test_boot_config_resolves_load_roots_and_source_dirs

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -2,7 +2,6 @@
 
 require_relative "test_helper"
 require "English"
-require "minitest/mock"
 require "tmpdir"
 require "mutineer/config"
 require "mutineer/daemon_backend"
@@ -29,8 +28,8 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
-  # SHARED is the contract. Drift either way (a new Runner. call in the backend, or
-  # a stale symbol left in the list) must fail here, not only when something privatises.
+  # SHARED is hand-maintained, so it can drift from the real call sites: add a sixth
+  # Runner call and the tripwire above still passes while no longer covering it.
   def test_shared_list_matches_runner_calls_in_daemon_backend_source
     src = File.read(File.expand_path("../lib/mutineer/daemon_backend.rb", __dir__))
     # Text scan, not a call graph. Two ways it misreads Ruby, both closed here:
@@ -46,6 +45,7 @@ class DaemonBackendContractTest < Minitest::Test
                 .uniq
                 .map(&:to_sym)
                 .sort
+
     assert_equal SHARED.sort, called,
                  "SHARED must list exactly the Runner methods daemon_backend.rb calls"
   end
@@ -94,86 +94,6 @@ class DaemonBackendContractTest < Minitest::Test
       assert_nil boot[:schema], "no db/schema.rb in this app, so the daemon skips worker-DB schema loading"
       assert boot[:rails]
       refute boot[:coverage], "worker daemons boot with Coverage off; only the map-building daemon enables it"
-    end
-  end
-
-  # Parallel workers must not drop mutants on crash: a raise used to leave a nil
-  # that compact removed, so the mutant vanished from AggregateResult. Mirror
-  # WorkerPool — keep every input slot as Result.error.
-  SOURCE = "class Order\n  def total(a, b)\n    a + b\n  end\nend\n"
-
-  # A real job pair, so the daemon paths run their actual code and the only stubbed
-  # thing is the daemon itself. Stubbing job_result instead would bypass the very
-  # rescue these tests exist to pin.
-  def with_jobs
-    Dir.mktmpdir("mutineer-daemon") do |root|
-      FileUtils.mkdir_p(File.join(root, "app"))
-      path = File.join(root, "app/order.rb")
-      File.binwrite(path, SOURCE)
-      subject = Mutineer::Project.discover([path]).first
-      mutations = Mutineer::Mutators::Arithmetic.new.mutations_for(subject, SOURCE)
-      config = Mutineer::Config.new(sources: [path], tests: [], project_root: root, framework: "minitest")
-      jobs = [[subject, mutations.first, "id-0"], [subject, mutations.first, "id-1"]]
-      yield jobs, config, { path => SOURCE }
-    end
-  end
-
-  # A crash running ONE mutant is that mutant's verdict, not the end of the run, and
-  # both daemon paths must agree on that or --jobs N stops matching --jobs 1.
-  def test_a_crash_running_one_mutant_is_an_error_verdict_on_both_paths
-    with_jobs do |jobs, config, source_map|
-      client = Object.new
-      def client.start = self
-      def client.quit = nil
-      def client.request(id:, **) = id.zero? ? raise("boom") : "killed"
-
-      %i[run_serial run_parallel].each do |path|
-        args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
-        results = Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
-          Mutineer::DaemonBackend.send(path, *args)
-        end
-
-        assert_equal 2, results.size, "#{path}: every input job must keep a slot"
-        assert_predicate results[0], :error?
-        assert_match(/daemon worker crashed/, results[0].details)
-        # subject and mutation, not just id: the reporter needs all three to place
-        # an errored mutant in its file and line, and dropping them still passes an
-        # id-only assertion.
-        assert_equal "id-0", results[0].id
-        assert_equal jobs[0][0], results[0].subject
-        assert_equal jobs[0][1], results[0].mutation
-        assert_predicate results[1], :killed?
-        assert_equal jobs[1][0], results[1].subject
-      end
-    end
-  end
-
-  # DaemonClient raises this only after exhausting its restart budget: the daemon is
-  # gone. Scoring the remaining mutants against it would print a score covering a
-  # fraction of the run, so the run must end instead.
-  def test_daemon_giving_up_ends_the_run_on_both_paths
-    with_jobs do |jobs, config, source_map|
-      client = Object.new
-      def client.start = self
-      def client.quit = nil
-      def client.request(**) = raise(Mutineer::DaemonBootError, "daemon crashed 3 times; aborting the run")
-
-      # The parallel path lets the abort escape a worker thread, and Ruby prints that
-      # trace by default. It is expected here, so keep it out of the suite's output.
-      reporting = Thread.report_on_exception
-      Thread.report_on_exception = false
-      begin
-        %i[run_serial run_parallel].each do |path|
-          args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
-          assert_raises(Mutineer::DaemonBootError, "#{path} must not score a run the daemon abandoned") do
-            Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
-              Mutineer::DaemonBackend.send(path, *args)
-            end
-          end
-        end
-      ensure
-        Thread.report_on_exception = reporting
-      end
     end
   end
 end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -18,6 +18,8 @@ class DaemonBackendContractTest < Minitest::Test
   # The Runner methods DaemonBackend calls across the module boundary.
   SHARED = %i[collect_jobs filter_since coverage_selection test_load_roots source_dirs].freeze
 
+  # Cheapest possible tripwire: privatising or renaming any of the five breaks the
+  # daemon path at runtime, and nothing else in the zero-dep suite would notice.
   def test_runner_publicly_answers_every_shared_invariant
     SHARED.each do |m|
       assert_respond_to Mutineer::Runner, m,

--- a/test/runner_daemon_test.rb
+++ b/test/runner_daemon_test.rb
@@ -6,7 +6,7 @@ require "mutineer/config"
 require "mutineer/runner"
 require "mutineer/cli"
 
-# #26/#27 Phase 2a (U4): Runner.execute_daemon drives the persistent daemon serially
+# #26/#27 Phase 2a (U4): DaemonBackend drives the persistent daemon serially
 # against the bundled fixture app and produces the SAME verdicts the in-process
 # `--rails` path is designed to produce — the R1 correctness identity, strategy held
 # constant (reload both sides). Tool-side runs in this process (Prism); only the
@@ -46,7 +46,7 @@ class RunnerDaemonTest < Minitest::Test
   end
 
   # Successful daemon coverage narrowing: no stale "lower bound / no narrowing"
-  # caveat. Fallback-only warnings live on Runner.daemon_coverage_map (nil map).
+  # caveat. Fallback-only warnings live on DaemonBackend.build_coverage_map (nil map).
   def test_cli_does_not_claim_stale_daemon_lower_bound_when_map_ok
     _out, err = capture_io do
       assert_raises(SystemExit) { Mutineer::CLI.execute(config_for("order_test.rb")) }
@@ -60,7 +60,7 @@ class RunnerDaemonTest < Minitest::Test
     cfg = config_for("order_test.rb")
     Mutineer::DaemonClient.stub(:new, ->(*) { raise Mutineer::DaemonBootError, "boom" }) do
       _out, err = capture_io do
-        map = Mutineer::Runner.daemon_coverage_map(cfg, cfg.tests.map { |t| File.expand_path(t, cfg.project_root) })
+        map = Mutineer::DaemonBackend.build_coverage_map(cfg, cfg.tests.map { |t| File.expand_path(t, cfg.project_root) })
         assert_nil map
       end
       assert_match(/daemon coverage map unavailable/, err)


### PR DESCRIPTION
Closes #58.

## What

`Runner` owned in-process, external and daemon orchestration plus job collection in one 662-line class-methods bag. This moves the daemon backend into `Mutineer::DaemonBackend` (`lib/mutineer/daemon_backend.rb`): job fan-out for both the serial and N-worker parallel paths, the app-side coverage-map build and its fallback warning, the daemon boot config and schema path, and the verdict-to-`Result` mapping. `Runner.execute` now delegates in one line.

`Runner` drops from 662 to 439 lines and keeps job collection, coverage selection and the single in-process mutant run.

## Why

Backend-specific changes were hard to review, and the three backends sitting in one class made it easy for their contracts to drift apart. That drift is the risk that matters here: if the daemon path and the in-process path ever disagree about which mutants run or which tests narrow a mutant, the daemon score stops being comparable to the in-process score, and Mutineer reports a number that is quietly wrong.

## How

The five shared invariants (`collect_jobs`, `filter_since`, `coverage_selection`, `test_load_roots`, `source_dirs`) deliberately stay on `Runner` and are called across the module boundary, so there is exactly one copy of each and the two paths cannot diverge. Method names lose the now-redundant `daemon_` prefix inside the namespace, and the six that nothing outside the file calls are private.

**One behaviour change, deliberate.** A daemon crash while running a single mutant used to propagate and end the whole run. It is now that mutant's `:error` verdict and the run continues, matching `WorkerPool` and the daemon's own in-band crash reply. A daemon that exhausts its restart budget still ends the run, because scoring the remainder against a dead daemon would report a score covering a fraction of the work. Both daemon paths share one classification, so `--jobs N` still matches `--jobs 1`. Caveat worth knowing before merge: errored mutants cannot currently fail the `--threshold` gate once any mutant is scored, which is older than this PR but newly reachable because of it. Filed as #78.

**The refactor itself changes nothing, verified mechanically rather than by eye.** Two reviewers independently extracted the nine method bodies from `e9ce883`, applied the rename map, and diffed against the new module. Every executable line is byte-identical; the only differences are the five `Runner.` qualifications.

## Review notes

The gate (`/ce-code-review` → `/ie-review` → `/cubic-loop`) found and fixed six things, each committed separately:

- **`daemon_backend.rb` called `Runner` without requiring it** — `require "mutineer/daemon_backend"` alone raised `NameError`.
- **The cure was worse than the disease** — declaring that dependency made Ruby print `circular require considered harmful` out of a shipped library on every `ruby -w` load, because `runner.rb` already requires `daemon_backend`. The require was dropped and the reason recorded in its place. Breaking the dependency properly means lifting the shared job vocabulary out of `Runner`, which is filed as #75.
- **The new cross-module contract was invisible to the local gate** — every test touching it lives in `DAEMON_TESTS`, excluded from `rake test`, so a rename would leave `rake test`, the load smoke and `yard:strict` all green while the daemon path raised at runtime. `test/daemon_backend_contract_test.rb` now guards it in the zero-dep suite. Confirmed it fails when one of the five is privatised.
- **That guard could pass while proving nothing** — three separate ways: a silent load failure, an installed `mutineer` gem satisfying the require from elsewhere, and (because stderr is merged) a backtrace naming the file satisfying the path check. All three are now closed, verified against four deliberately broken trees.
- **The CHANGELOG oversold the result** — it claimed the new module mirrors `ExternalBackend`. It does not: `Runner` calls into `ExternalBackend` one way, while `DaemonBackend` owns its orchestration and calls back. Both the convention and simplicity lenses flagged it. The wording now says what shipped, and the module doc names the asymmetry.
- **`TIMEOUT` was more generic than every sibling constant** — now `DEFAULT_TIMEOUT`, matching `Isolation::DEFAULT_TIMEOUT`.

**Accepted trade-off:** `require "mutineer/daemon_backend"` on its own still raises `NameError`, which is the state every release has shipped. Chosen over emitting a warning into users’ processes; #75 is the real fix.

**Not fixed here, filed instead:** #76 — `--daemon --since` with an empty job list boots the app N+1 times. Pre-existing, and README documents that exact invocation for PR CI.

## Testing

- `rake test` — 412 runs, 1170 assertions, 0 failures (up from 409; the 3 new ones are the contract guard)
- `rake test:daemon` — 14 runs, 60 assertions, 0 failures
- `rake yard:strict` — 100% documented
- `ruby -Ilib -e 'require "mutineer"'` clean, and clean under `-w`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfCKGYtEpcYLtp71Rsqf3h
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->