### PR TITLE
fix(daemon): a dead daemon ends the run instead of scoring the rest against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Changed
+- **A daemon crash while running one mutant no longer ends the whole run** — it
+  used to propagate and abort with a backtrace, on both `--jobs 1` and
+  `--jobs N`. That mutant is now scored `:error` and the run continues, matching
+  `WorkerPool` and the daemon's own in-band crash reply. Errors stay outside the
+  score denominator. A daemon that exhausts its restart budget still ends the
+  run: `DaemonClient` raises after `MAX_RESTARTS`, and scoring the remaining
+  mutants against a dead daemon would report a score covering a fraction of the
+  work. Both daemon paths share one classification, so `--jobs N` still matches
+  `--jobs 1`. Errored mutants cannot yet fail the `--threshold` gate once any
+  mutant is scored (#78).
 - **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
   (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now
   lives in `Mutineer::DaemonBackend`. `Runner` keeps job collection, coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ All notable changes to this project are documented here. The format is based on
   used to propagate and abort with a backtrace, on both `--jobs 1` and
   `--jobs N`. That mutant is now scored `:error` and the run continues, matching
   `WorkerPool` and the daemon's own in-band crash reply. Errors stay outside the
-  score denominator. A daemon that exhausts its restart budget still ends the
-  run: `DaemonClient` raises after `MAX_RESTARTS`, and scoring the remaining
-  mutants against a dead daemon would report a score covering a fraction of the
-  work. Both daemon paths share one classification, so `--jobs N` still matches
-  `--jobs 1`. Errored mutants cannot yet fail the `--threshold` gate once any
-  mutant is scored (#78).
+  score denominator. A daemon that is gone for good still ends the run, because
+  scoring the remaining mutants against it would report a score covering a
+  fraction of the work: `DaemonClient` raises `DaemonBootError` after
+  `MAX_RESTARTS` crashes, when a respawned daemon fails its boot handshake, when
+  the OS refuses the spawn, and when its pipes have been closed. The CLI reports
+  that as a message and exit 1 rather than a backtrace. Both daemon paths share
+  one classification, so `--jobs N` still matches `--jobs 1`. Only the daemon
+  call is guarded: a fault in the tool-side work stays fatal rather than becoming
+  an error verdict on every mutant. Errored mutants cannot yet fail the
+  `--threshold` gate once any mutant is scored (#78).
 - **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
   (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now
   lives in `Mutineer::DaemonBackend`. `Runner` keeps job collection, coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,23 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **A dead daemon ends the run instead of scoring the rest against it** — a
+  daemon that dies while running one mutant was already handled: `DaemonClient`
+  respawns and answers `error` for that mutant. But a daemon that could not come
+  back was not. `restart!` closes the pipes before respawning, so if the respawn
+  failed at the OS level (`EMFILE` or `ENOMEM` under `--jobs N`, `ENOENT` when
+  `bundle` does not resolve) the client was left permanently dead while raising
+  errors that read as ordinary per-mutant failures. Every remaining mutant scored
+  `error` against nothing, and Mutineer printed a mutation score built on the
+  fraction of mutants that ran before the daemon died. `DaemonClient` now raises
+  `DaemonBootError` whenever it is gone for good — a refused spawn, a failed boot
+  handshake on respawn, closed pipes, or `MAX_RESTARTS` crashes — and the CLI
+  reports it as a message and exit 1 rather than a backtrace. Under `--jobs N`
+  the remaining queue is dropped so sibling workers stop too. Errored mutants
+  still cannot fail the `--threshold` gate once any mutant is scored (#78).
+
 ### Changed
-- **A daemon crash while running one mutant no longer ends the whole run** — it
-  used to propagate and abort with a backtrace, on both `--jobs 1` and
-  `--jobs N`. That mutant is now scored `:error` and the run continues, matching
-  `WorkerPool` and the daemon's own in-band crash reply. Errors stay outside the
-  score denominator. A daemon that is gone for good still ends the run, because
-  scoring the remaining mutants against it would report a score covering a
-  fraction of the work: `DaemonClient` raises `DaemonBootError` after
-  `MAX_RESTARTS` crashes, when a respawned daemon fails its boot handshake, when
-  the OS refuses the spawn, and when its pipes have been closed. The CLI reports
-  that as a message and exit 1 rather than a backtrace. Both daemon paths share
-  one classification, so `--jobs N` still matches `--jobs 1`. Only the daemon
-  call is guarded: a fault in the tool-side work stays fatal rather than becoming
-  an error verdict on every mutant. Errored mutants cannot yet fail the
-  `--threshold` gate once any mutant is scored (#78).
 - **Daemon orchestration split out of `Runner`** — the persistent-daemon backend
   (job fan-out, worker DBs, coverage-map build, boot config, verdict mapping) now
   lives in `Mutineer::DaemonBackend`. `Runner` keeps job collection, coverage

--- a/lib/mutineer/cli.rb
+++ b/lib/mutineer/cli.rb
@@ -214,6 +214,11 @@ module Mutineer
       # environment, not weak tests. Runtime error (exit 1), not usage (exit 2).
       warn "mutineer: #{e.message}"
       exit 1
+    rescue Mutineer::DaemonBootError => e
+      # The daemon is gone for good, so the run ended rather than scoring the rest
+      # against it. A deliberate stop deserves a message, not a raw backtrace.
+      warn "mutineer: #{e.message}"
+      exit 1
     end
 
     # Flag validation: every flag/usage failure exits 2, consistent with the

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -136,10 +136,12 @@ module Mutineer
     # Parallel path: N daemon handles, each pinned to its own worker slot (own DB).
     # A shared queue of job indices feeds N tool-side threads; results are placed by
     # input index so the verdict set matches serial. Callers must not pass fail_fast
-    # here ({execute} forces serial for fail-fast).
+    # here ({execute} forces serial for fail-fast). Per-mutant crashes are classified
+    # in {job_result}, shared with the serial path; a {DaemonBootError} ends the run
+    # here rather than scoring the remainder against a daemon that has given up.
     #
     # @api private
-    # @return [Array<Mutineer::Result>] completed results in input order.
+    # @return [Array<Mutineer::Result>] one result per input job, in input order.
     def self.run_parallel(jobs, worker_count, config, abs_tests, coverage_map, source_map)
       results = Array.new(jobs.size)
       queue   = Queue.new
@@ -160,22 +162,39 @@ module Mutineer
             end
             results[i] = job_result(jobs[i], i, client, worker, config, coverage_map, abs_tests, source_map)
           end
+        rescue DaemonBootError
+          # The daemon gave up for good. Stop feeding the other workers rather
+          # than letting them score the rest of the run against a dead client;
+          # Thread#join re-raises this and ends the run.
+          queue.clear
+          raise
         ensure
           client.quit
         end
       end.each(&:join)
 
-      results.compact
+      # Every job was popped by some worker and every pop assigns, so no slot can
+      # be nil here: an escaping exception aborts the run via join instead.
+      results
     end
 
     # Build the payload for one job, run it on the given daemon/worker, and attach
-    # the subject/mutation/id. Shared body of both daemon paths.
+    # the subject/mutation/id. Shared body of both daemon paths, so `--jobs 1` and
+    # `--jobs N` classify an identical fault identically.
+    #
+    # Error model, in one place because both paths call this: a crash while running
+    # ONE mutant is that mutant's `error` verdict and the run continues, matching
+    # {WorkerPool} and the daemon's own in-band crash reply. {DaemonBootError} is
+    # different — it is DaemonClient's signal that the daemon is gone for good after
+    # MAX_RESTARTS — so it propagates and ends the run. Scoring the remaining mutants
+    # against a dead daemon would print a score built on a fraction of the work.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
     # @param client [Mutineer::DaemonClient] the daemon handle to run on.
     # @param worker [Integer] the worker slot (→ worker DB) this daemon routes to.
     # @api private
+    # @raise [Mutineer::DaemonBootError] when the daemon has given up; ends the run.
     # @return [Mutineer::Result] the decorated result.
     def self.job_result(job, req_id, client, worker, config, coverage_map, abs_tests, source_map)
       subject, mutation, id = job
@@ -202,6 +221,11 @@ module Mutineer
           result_for(verdict)
         end
       r.with(subject: subject, mutation: mutation, id: id)
+    rescue DaemonBootError
+      raise
+    rescue StandardError => e
+      Result.error("daemon worker crashed: #{e.class}: #{e.message}")
+        .with(subject: subject, mutation: mutation, id: id)
     end
 
     # The boot config the daemon needs to boot the app once: where to boot, the test

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -187,13 +187,12 @@ module Mutineer
     # `--jobs N` classify an identical fault identically.
     #
     # Error model, in one place because both paths call this: a crash while running
-    # ONE mutant is that mutant's `error` verdict and the run continues, matching
-    # {WorkerPool} and the daemon's own in-band crash reply. {DaemonBootError} is
-    # different — DaemonClient raises it when the daemon is gone for good (a failed
-    # boot handshake, a spawn the OS refused, or MAX_RESTARTS crashes) — so it
-    # propagates and ends the run. Scoring the remaining mutants against a dead
-    # daemon would print a score built on a fraction of the work. Anyone adding a
-    # second fatal error class must re-raise it alongside {DaemonBootError} below.
+    # ONE mutant is already {DaemonClient}'s business: it rescues the dead pipe,
+    # respawns, and answers `"error"` for that mutant, so the run continues. Nothing
+    # is caught here on purpose — an exception reaching this far is either
+    # {DaemonBootError} (the daemon is gone for good, so the run must end rather than
+    # score the rest against it) or a defect, and absorbing a defect into one more
+    # errored mutant is how a broken run comes to look like a weak test suite.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
@@ -219,22 +218,12 @@ module Mutineer
         elsif sel && sel[0] == :verdict
           sel[1]
         else
-          # Only the daemon call is guarded. A fault in the tool-side work above
-          # (apply, the Prism parse, coverage selection) is deterministic — it would
-          # hit every mutant — so it must stay fatal instead of becoming N error
-          # verdicts and an empty denominator.
-          begin
-            verdict = client.request(
-              id: req_id, worker: worker, timeout: config.daemon_timeout || DEFAULT_TIMEOUT,
-              payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
-              tests: sel ? sel[1] : abs_tests
-            )
-            result_for(verdict)
-          rescue DaemonBootError
-            raise
-          rescue StandardError => e
-            Result.error("daemon worker crashed: #{e.class}: #{e.message}")
-          end
+          verdict = client.request(
+            id: req_id, worker: worker, timeout: config.daemon_timeout || DEFAULT_TIMEOUT,
+            payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
+            tests: sel ? sel[1] : abs_tests
+          )
+          result_for(verdict)
         end
       r.with(subject: subject, mutation: mutation, id: id)
     end

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -147,9 +147,17 @@ module Mutineer
       queue   = Queue.new
       jobs.each_index { |i| queue << i }
 
-      clients = Array.new(worker_count) do
-        DaemonClient.new(boot: boot_config(config, abs_tests),
-                         app_root: config.project_root).start
+      # Built one at a time so a refused spawn part-way (EMFILE under a high --jobs)
+      # can still quit the daemons already up. Array.new would lose every reference.
+      clients = []
+      begin
+        worker_count.times do
+          clients << DaemonClient.new(boot: boot_config(config, abs_tests),
+                                      app_root: config.project_root).start
+        end
+      rescue StandardError
+        clients.each(&:quit)
+        raise
       end
 
       clients.each_with_index.map do |client, worker|
@@ -187,12 +195,9 @@ module Mutineer
     # `--jobs N` classify an identical fault identically.
     #
     # Error model, in one place because both paths call this: a crash while running
-    # ONE mutant is already {DaemonClient}'s business: it rescues the dead pipe,
-    # respawns, and answers `"error"` for that mutant, so the run continues. Nothing
-    # is caught here on purpose — an exception reaching this far is either
-    # {DaemonBootError} (the daemon is gone for good, so the run must end rather than
-    # score the rest against it) or a defect, and absorbing a defect into one more
-    # errored mutant is how a broken run comes to look like a weak test suite.
+    # ONE mutant is {DaemonClient}'s business: it respawns and answers `"error"`.
+    # Nothing is caught here on purpose — anything reaching this far is either
+    # {DaemonBootError}, which must end the run, or a defect, which must stay visible.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -154,6 +154,10 @@ module Mutineer
 
       clients.each_with_index.map do |client, worker|
         Thread.new do
+          # The abort below is re-raised by join and reported once there; without
+          # this Ruby also dumps the thread's backtrace, which the serial path never
+          # does. Same fault, same output, whatever --jobs is set to.
+          Thread.current.report_on_exception = false
           loop do
             i = begin
               queue.pop(true)
@@ -185,9 +189,11 @@ module Mutineer
     # Error model, in one place because both paths call this: a crash while running
     # ONE mutant is that mutant's `error` verdict and the run continues, matching
     # {WorkerPool} and the daemon's own in-band crash reply. {DaemonBootError} is
-    # different — it is DaemonClient's signal that the daemon is gone for good after
-    # MAX_RESTARTS — so it propagates and ends the run. Scoring the remaining mutants
-    # against a dead daemon would print a score built on a fraction of the work.
+    # different — DaemonClient raises it when the daemon is gone for good (a failed
+    # boot handshake, a spawn the OS refused, or MAX_RESTARTS crashes) — so it
+    # propagates and ends the run. Scoring the remaining mutants against a dead
+    # daemon would print a score built on a fraction of the work. Anyone adding a
+    # second fatal error class must re-raise it alongside {DaemonBootError} below.
     #
     # @param job [Array(Mutineer::Subject, Mutineer::Mutation, String)] the work item.
     # @param req_id [Integer] request id (echoed back for IPC ordering safety).
@@ -213,19 +219,24 @@ module Mutineer
         elsif sel && sel[0] == :verdict
           sel[1]
         else
-          verdict = client.request(
-            id: req_id, worker: worker, timeout: config.daemon_timeout || DEFAULT_TIMEOUT,
-            payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
-            tests: sel ? sel[1] : abs_tests
-          )
-          result_for(verdict)
+          # Only the daemon call is guarded. A fault in the tool-side work above
+          # (apply, the Prism parse, coverage selection) is deterministic — it would
+          # hit every mutant — so it must stay fatal instead of becoming N error
+          # verdicts and an empty denominator.
+          begin
+            verdict = client.request(
+              id: req_id, worker: worker, timeout: config.daemon_timeout || DEFAULT_TIMEOUT,
+              payload: { "code" => mutated, "source_file" => File.expand_path(subject.file, config.project_root) },
+              tests: sel ? sel[1] : abs_tests
+            )
+            result_for(verdict)
+          rescue DaemonBootError
+            raise
+          rescue StandardError => e
+            Result.error("daemon worker crashed: #{e.class}: #{e.message}")
+          end
         end
       r.with(subject: subject, mutation: mutation, id: id)
-    rescue DaemonBootError
-      raise
-    rescue StandardError => e
-      Result.error("daemon worker crashed: #{e.class}: #{e.message}")
-        .with(subject: subject, mutation: mutation, id: id)
     end
 
     # The boot config the daemon needs to boot the app once: where to boot, the test

--- a/lib/mutineer/daemon_client.rb
+++ b/lib/mutineer/daemon_client.rb
@@ -133,30 +133,34 @@ module Mutineer
       # non-rbenv setup. When bundler/ruby are rbenv shims, the RBENV_VERSION
       # carried in app_env still selects the app's Ruby; otherwise the active
       # Ruby is used.
-      # A spawn the OS refuses (EMFILE/ENOMEM under --jobs N, ENOENT when `bundle`
-      # does not resolve) is terminal, not one mutant's problem: close_io has already
-      # nilled the pipes, so the client cannot recover. Raise the class that ends the
-      # run rather than a SystemCallError the backend would score per-mutant.
-      begin
-        @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
-          app_env, "bundle", "exec", "ruby",
-          "-r", DAEMON_PATH, "-e", "Mutineer::DaemonServer.run", chdir: @app_root
-        )
-      rescue SystemCallError => e
-        raise DaemonBootError, "daemon could not be spawned: #{e.class}: #{e.message}"
-      end
-      # Drain daemon stderr to the tool's stderr so child/boot errors are visible.
-      # Tracked (not fire-and-forget) so close_io can reclaim it on quit/respawn;
-      # the rescue swallows the benign EBADF/IOError raised when close_io closes
-      # the pipe out from under an in-flight copy_stream.
-      @drain = Thread.new do # rubocop:disable ThreadSafety/NewThread
-        IO.copy_stream(@stderr, @errio)
-      rescue IOError, Errno::EBADF
-        nil
-      end
+      # Everything up to the handshake is terminal, not one mutant's problem: a spawn
+      # the OS refuses (EMFILE/ENOMEM under --jobs N, ENOENT when `bundle` does not
+      # resolve) and a daemon that dies before accepting the boot payload (EPIPE on
+      # the write) both leave a client that cannot recover. Raise the class that ends
+      # the run — a SystemCallError would reach the CLI as a usage error (exit 2).
+      ready =
+        begin
+          @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
+            app_env, "bundle", "exec", "ruby",
+            "-r", DAEMON_PATH, "-e", "Mutineer::DaemonServer.run", chdir: @app_root
+          )
+          # Drain daemon stderr to the tool's stderr so child/boot errors are visible.
+          # Tracked (not fire-and-forget) so close_io can reclaim it on quit/respawn;
+          # the rescue swallows the benign EBADF/IOError raised when close_io closes
+          # the pipe out from under an in-flight copy_stream.
+          @drain = Thread.new do # rubocop:disable ThreadSafety/NewThread
+            IO.copy_stream(@stderr, @errio)
+          rescue IOError, Errno::EBADF
+            nil
+          end
 
-      send_line(@boot)
-      ready = read_line
+          send_line(@boot)
+          read_line
+        rescue SystemCallError, IOError => e
+          close_io
+          raise DaemonBootError, "daemon could not be started: #{e.class}: #{e.message}"
+        end
+
       unless ready && ready["ready"]
         detail = ready && ready["error"] ? ready["error"] : "daemon exited before the handshake"
         close_io

--- a/lib/mutineer/daemon_client.rb
+++ b/lib/mutineer/daemon_client.rb
@@ -4,8 +4,11 @@ require "json"
 require "open3"
 
 module Mutineer
-  # Raised when the daemon cannot be booted (bad boot path, app error, or it dies
-  # on the handshake). The CLI maps it to a runtime error.
+  # Raised when the daemon cannot be booted or is gone for good: a bad boot path, an
+  # app error, a failed handshake, a spawn the OS refused, or MAX_RESTARTS crashes.
+  # It means "stop the run" — a backend that scored the remaining mutants against a
+  # dead daemon would report a score covering a fraction of the work. The CLI maps it
+  # to a runtime error (exit 1).
   class DaemonBootError < StandardError; end
 
   # Tool-side handle for the app-side daemon.
@@ -60,6 +63,12 @@ module Mutineer
     #   `<db>-<worker>` for isolation. Defaults to 0 (serial).
     # @return [String] one of survived/killed/error/timeout.
     def request(id:, payload:, tests:, timeout:, worker: 0)
+      # close_io nils the pipes, so a client whose respawn never completed would
+      # otherwise fail per-mutant forever (NoMethodError on nil) and let the backend
+      # score every remaining mutant against nothing. Deadness is a property of the
+      # client, not of whichever exception happened to escape.
+      raise DaemonBootError, "daemon is not running" if @stdin.nil?
+
       # A crash can surface on the WRITE (daemon died idle between requests →
       # Errno::EPIPE) as well as the read (EOF), so guard both: either way, respawn
       # for future mutants and score THIS one error (re-running a crash-causing
@@ -124,10 +133,18 @@ module Mutineer
       # non-rbenv setup. When bundler/ruby are rbenv shims, the RBENV_VERSION
       # carried in app_env still selects the app's Ruby; otherwise the active
       # Ruby is used.
-      @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
-        app_env, "bundle", "exec", "ruby",
-        "-r", DAEMON_PATH, "-e", "Mutineer::DaemonServer.run", chdir: @app_root
-      )
+      # A spawn the OS refuses (EMFILE/ENOMEM under --jobs N, ENOENT when `bundle`
+      # does not resolve) is terminal, not one mutant's problem: close_io has already
+      # nilled the pipes, so the client cannot recover. Raise the class that ends the
+      # run rather than a SystemCallError the backend would score per-mutant.
+      begin
+        @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
+          app_env, "bundle", "exec", "ruby",
+          "-r", DAEMON_PATH, "-e", "Mutineer::DaemonServer.run", chdir: @app_root
+        )
+      rescue SystemCallError => e
+        raise DaemonBootError, "daemon could not be spawned: #{e.class}: #{e.message}"
+      end
       # Drain daemon stderr to the tool's stderr so child/boot errors are visible.
       # Tracked (not fire-and-forget) so close_io can reclaim it on quit/respawn;
       # the rescue swallows the benign EBADF/IOError raised when close_io closes

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "test_helper"
 require "English"
+require "minitest/mock"
 require "tmpdir"
 require "mutineer/config"
 require "mutineer/daemon_backend"
@@ -67,6 +68,83 @@ class DaemonBackendContractTest < Minitest::Test
       assert_nil boot[:schema], "no db/schema.rb in this app, so the daemon skips worker-DB schema loading"
       assert boot[:rails]
       refute boot[:coverage], "worker daemons boot with Coverage off; only the map-building daemon enables it"
+    end
+  end
+
+  SOURCE = "class Order\n  def total(a, b)\n    a + b\n  end\nend\n"
+
+  # A real job pair, so the daemon paths run their actual code and the only stubbed
+  # thing is the daemon itself. Stubbing job_result instead would bypass the very
+  # rescue these tests exist to pin.
+  def with_jobs
+    Dir.mktmpdir("mutineer-daemon") do |root|
+      FileUtils.mkdir_p(File.join(root, "app"))
+      path = File.join(root, "app/order.rb")
+      File.binwrite(path, SOURCE)
+      subject = Mutineer::Project.discover([path]).first
+      mutations = Mutineer::Mutators::Arithmetic.new.mutations_for(subject, SOURCE)
+      config = Mutineer::Config.new(sources: [path], tests: [], project_root: root, framework: "minitest")
+      jobs = [[subject, mutations.first, "id-0"], [subject, mutations.first, "id-1"]]
+      yield jobs, config, { path => SOURCE }
+    end
+  end
+
+  # A crash running ONE mutant is that mutant's verdict, not the end of the run, and
+  # both daemon paths must agree on that or --jobs N stops matching --jobs 1.
+  def test_a_crash_running_one_mutant_is_an_error_verdict_on_both_paths
+    with_jobs do |jobs, config, source_map|
+      client = Object.new
+      def client.start = self
+      def client.quit = nil
+      def client.request(id:, **) = id.zero? ? raise("boom") : "killed"
+
+      %i[run_serial run_parallel].each do |path|
+        args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
+        results = Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+          Mutineer::DaemonBackend.send(path, *args)
+        end
+
+        assert_equal 2, results.size, "#{path}: every input job must keep a slot"
+        assert_predicate results[0], :error?
+        assert_match(/daemon worker crashed/, results[0].details)
+        # subject and mutation, not just id: the reporter needs all three to place
+        # an errored mutant at its file and line, and dropping them still passes an
+        # id-only assertion.
+        assert_equal "id-0", results[0].id
+        assert_equal jobs[0][0], results[0].subject
+        assert_equal jobs[0][1], results[0].mutation
+        assert_predicate results[1], :killed?
+        assert_equal jobs[1][0], results[1].subject
+      end
+    end
+  end
+
+  # DaemonClient raises this only after exhausting its restart budget: the daemon is
+  # gone, and close_io has already run, so every later request would fail too. Scoring
+  # the rest against it would print a score covering a fraction of the run.
+  def test_daemon_giving_up_ends_the_run_on_both_paths
+    with_jobs do |jobs, config, source_map|
+      client = Object.new
+      def client.start = self
+      def client.quit = nil
+      def client.request(**) = raise(Mutineer::DaemonBootError, "daemon crashed 3 times; aborting the run")
+
+      # The parallel path lets the abort escape a worker thread, and Ruby prints that
+      # trace by default. It is expected here, so keep it out of the suite's output.
+      reporting = Thread.report_on_exception
+      Thread.report_on_exception = false
+      begin
+        %i[run_serial run_parallel].each do |path|
+          args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
+          assert_raises(Mutineer::DaemonBootError, "#{path} must not score a run the daemon abandoned") do
+            Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+              Mutineer::DaemonBackend.send(path, *args)
+            end
+          end
+        end
+      ensure
+        Thread.report_on_exception = reporting
+      end
     end
   end
 end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -89,14 +89,15 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
-  # A crash running ONE mutant is that mutant's verdict, not the end of the run, and
-  # both daemon paths must agree on that or --jobs N stops matching --jobs 1.
+  # A daemon that dies on ONE mutant is DaemonClient's business: it respawns and
+  # answers "error" for that mutant. The run must carry on, identically on both
+  # paths, or --jobs N stops matching --jobs 1.
   def test_a_crash_running_one_mutant_is_an_error_verdict_on_both_paths
     with_jobs do |jobs, config, source_map|
       client = Object.new
       def client.start = self
       def client.quit = nil
-      def client.request(id:, **) = id.zero? ? raise("boom") : "killed"
+      def client.request(id:, **) = id.zero? ? "error" : "killed"
 
       %i[run_serial run_parallel].each do |path|
         args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
@@ -106,7 +107,7 @@ class DaemonBackendContractTest < Minitest::Test
 
         assert_equal 2, results.size, "#{path}: every input job must keep a slot"
         assert_predicate results[0], :error?
-        assert_match(/daemon worker crashed/, results[0].details)
+        assert_match(/daemon verdict: error/, results[0].details)
         # subject and mutation, not just id: the reporter needs all three to place
         # an errored mutant at its file and line, and dropping them still passes an
         # id-only assertion.

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -129,22 +129,95 @@ class DaemonBackendContractTest < Minitest::Test
       def client.quit = nil
       def client.request(**) = raise(Mutineer::DaemonBootError, "daemon crashed 3 times; aborting the run")
 
-      # The parallel path lets the abort escape a worker thread, and Ruby prints that
-      # trace by default. It is expected here, so keep it out of the suite's output.
-      reporting = Thread.report_on_exception
-      Thread.report_on_exception = false
-      begin
-        %i[run_serial run_parallel].each do |path|
-          args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
-          assert_raises(Mutineer::DaemonBootError, "#{path} must not score a run the daemon abandoned") do
-            Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
-              Mutineer::DaemonBackend.send(path, *args)
-            end
+      %i[run_serial run_parallel].each do |path|
+        args = path == :run_serial ? [jobs, config, [], nil, source_map] : [jobs, 2, config, [], nil, source_map]
+        assert_raises(Mutineer::DaemonBootError, "#{path} must not score a run the daemon abandoned") do
+          Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+            Mutineer::DaemonBackend.send(path, *args)
           end
         end
-      ensure
-        Thread.report_on_exception = reporting
       end
+    end
+  end
+
+  # A fault in the tool-side work (apply, the Prism parse, coverage selection) is
+  # deterministic: it hits every mutant. Turning it into N error verdicts would empty
+  # the denominator and blame the daemon, so it must stay fatal.
+  def test_a_tool_side_fault_still_ends_the_run
+    with_jobs do |jobs, config, _source_map|
+      client = Object.new
+      def client.start = self
+      def client.quit = nil
+      def client.request(**) = "killed"
+
+      # An empty source_map makes mutation.apply fail on nil, before the daemon call.
+      assert_raises(StandardError) do
+        Mutineer::DaemonClient.stub(:new, ->(**) { client }) do
+          Mutineer::DaemonBackend.send(:run_serial, jobs, config, [], nil, {})
+        end
+      end
+    end
+  end
+
+  # DaemonBootError is not the only way a client dies: close_io nils the pipes before
+  # a respawn, so a client whose respawn failed would otherwise fail per-mutant
+  # forever and let the run score every remaining mutant against nothing.
+  def test_a_client_whose_pipes_are_gone_reports_itself_dead
+    client = Mutineer::DaemonClient.allocate
+    client.instance_variable_set(:@stdin, nil)
+
+    error = assert_raises(Mutineer::DaemonBootError) do
+      client.request(id: 0, payload: {}, tests: [], timeout: 1)
+    end
+    assert_match(/not running/, error.message)
+  end
+
+  # queue.clear is the only parallel-specific logic here, and deleting it left the
+  # suite green: join re-raises either way. Pin the sibling stop with more jobs than
+  # workers, so a healthy worker cannot quietly finish the whole queue.
+  def test_a_dead_daemon_stops_the_other_workers
+    with_jobs do |jobs, config, source_map| # rubocop:disable Lint/UnusedBlockArgument
+      subject, mutation, = jobs.first
+      many = Array.new(12) { |i| [subject, mutation, "id-#{i}"] }
+      map = { subject.file => SOURCE }
+
+      # A latch rather than a sleep: the healthy worker holds inside its first request
+      # until the dying one has aborted, so what it does next is decided by whether
+      # the queue was drained, not by timing.
+      gate = Queue.new
+
+      dying = Object.new
+      dying.instance_variable_set(:@gate, gate)
+      def dying.start = self
+      def dying.quit = nil
+      def dying.request(**)
+        @gate << :aborted
+        raise(Mutineer::DaemonBootError, "daemon crashed 3 times; aborting the run")
+      end
+
+      healthy = Object.new
+      healthy.instance_variable_set(:@seen, [])
+      healthy.instance_variable_set(:@gate, gate)
+      def healthy.start = self
+      def healthy.quit = nil
+      def healthy.seen = @seen
+      def healthy.request(id:, **)
+        @seen << id
+        @gate.pop      # wait for the abort
+        @gate << :done # never block a later call
+        "killed"
+      end
+
+      queue = [dying, healthy]
+      assert_raises(Mutineer::DaemonBootError) do
+        Mutineer::DaemonClient.stub(:new, ->(**) { queue.shift }) do
+          Mutineer::DaemonBackend.send(:run_parallel, many, 2, config, [], nil, map)
+        end
+      end
+
+      assert_operator healthy.seen.size, :<=, 2,
+                      "the healthy worker kept draining the queue after the daemon gave up " \
+                      "(#{healthy.seen.size} of #{many.size} jobs)"
     end
   end
 end

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -71,6 +71,8 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
+  # Mutatable fixture for the daemon-path tests: one arithmetic operator, so the
+  # Arithmetic mutator yields a real Mutation to send through job_result.
   SOURCE = "class Order\n  def total(a, b)\n    a + b\n  end\nend\n"
 
   # A real job pair, so the daemon paths run their actual code and the only stubbed
@@ -171,6 +173,21 @@ class DaemonBackendContractTest < Minitest::Test
       client.request(id: 0, payload: {}, tests: [], timeout: 1)
     end
     assert_match(/not running/, error.message)
+  end
+
+  # A daemon that dies before accepting the boot payload makes the write raise
+  # Errno::EPIPE. Left as a SystemCallError it reaches the CLI as a usage error
+  # (exit 2), which would tell CI the flags were wrong rather than the daemon died.
+  def test_a_daemon_that_dies_before_the_handshake_is_a_boot_error
+    client = Mutineer::DaemonClient.allocate
+    client.instance_variable_set(:@boot, {})
+    client.instance_variable_set(:@app_root, Dir.pwd)
+    client.instance_variable_set(:@errio, StringIO.new)
+    def client.app_env = {}
+    def client.send_line(_obj) = raise(Errno::EPIPE)
+
+    error = assert_raises(Mutineer::DaemonBootError) { client.send(:spawn_daemon) }
+    assert_match(/could not be started/, error.message)
   end
 
   # queue.clear is the only parallel-specific logic here, and deleting it left the


### PR DESCRIPTION
Split out of #77, which was a behaviour-preserving move. Follows #58.

## What

A daemon that cannot come back now ends the run, instead of leaving every remaining mutant to score `error` against a dead client while Mutineer prints a mutation score.

## Why

`DaemonClient` already handles a daemon that dies **while running one mutant**: it rescues the dead pipe, respawns, and answers `error` for that mutant, so the run carries on. That part was never broken.

What was missing is the daemon that **cannot come back**. `restart!` calls `close_io` before respawning, so if the respawn fails at the OS level — `EMFILE` or `ENOMEM` under `--jobs N`, `ENOENT` when `bundle` does not resolve — the client is left permanently dead, with `@stdin` nil. Those failures surface as `SystemCallError` and then `NoMethodError` on nil, which read as ordinary per-mutant faults. Every remaining mutant scores `error` against nothing, the run completes, and the score covers only the mutants that ran before the daemon died.

For a tool whose entire promise is an honest score, a run that quietly reports on a fraction of its work is the worst failure available.

## How

Make deadness a property of the client rather than of whichever exception escaped:

- `spawn_daemon` converts a refused spawn into `DaemonBootError`
- `request` raises `DaemonBootError` when the pipes are gone
- `job_result` catches nothing, so `DaemonBootError` ends the run and a defect stays visible
- `run_parallel` drops the remaining queue on that signal, so sibling workers stop instead of scoring against a dead daemon
- `CLI.run` rescues `DaemonBootError` and reports it as a message with exit 1, rather than a raw backtrace. The docstring claiming "the CLI maps it to a runtime error" was false until now
- the worker thread stops printing its own exception report, so an abort reads the same at `--jobs 1` and `--jobs N`

## Review history worth knowing

This PR started as a change to *classify* daemon crashes, carried over from review of #77. Three reviewers found that its rescue swallowed `DaemonClient`'s own give-up signal, which reopened the mass-error hole. Fixing that, cubic then flagged the rescue as hiding real defects — and following that through showed the per-mutant behaviour it claimed to add was already there, delivered a layer down by `DaemonClient`. So the rescue is gone entirely and what is left is the guard that was genuinely missing.

## Known gap

**#78:** errored mutants cannot fail the `--threshold` gate once any mutant is scored. Older than this PR and not fixed here — the fix is a product decision, and v0.11.1 chose the current behaviour deliberately in #49.

## Testing

Four zero-dep tests, each verified to fail when its guard is removed:

- a wedged client reports itself dead rather than failing per-mutant
- a tool-side fault still ends the run
- a dead daemon stops the sibling workers — latched rather than timed, because the timed version passed with `queue.clear` deleted
- a per-mutant daemon crash is still just that mutant's `error`, identically on both paths

`rake test` 417 runs / 1196 assertions, `rake test:daemon` 14 runs, `yard:strict` 100%, cubic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfCKGYtEpcYLtp71Rsqf3h
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->