### PR TITLE
fix: nothing to mutate now costs nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Fixed
-- **`--daemon` with nothing to mutate boots nothing** — `--since` matching no
-  changed line (a docs-only PR, which README documents `--since origin/<base>`
-  for) still booted the app once for the coverage map and again for every
-  `--jobs` worker, to score zero mutants. The daemon path now returns before
-  booting anything when the job list is empty (#76).
+- **Nothing to mutate now costs nothing** — `--since` matching no changed line (a
+  docs-only PR, which README documents `--since origin/<base>` for) still did the
+  expensive part before discovering there was no work: `--daemon` booted the app
+  once for the coverage map and again for every `--jobs` worker, and
+  `--test-command` ran the whole suite for a smoke check that calibrates a timeout
+  no mutant would use. Both backends now return as soon as the job list is empty.
+  The in-process path is unchanged: it boots before collecting jobs, so it cannot
+  know the list is empty yet. One consequence worth stating: a zero-job `--daemon`
+  run no longer boots the app, so an app that fails to boot now exits 0 (nothing
+  to do) instead of exit 1 (#76).
 - **A dead daemon ends the run instead of scoring the rest against it** — a
   daemon that dies while running one mutant was already handled: `DaemonClient`
   respawns and answers `error` for that mutant. But a daemon that could not come

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Fixed
+- **`--daemon` with nothing to mutate boots nothing** — `--since` matching no
+  changed line (a docs-only PR, which README documents `--since origin/<base>`
+  for) still booted the app once for the coverage map and again for every
+  `--jobs` worker, to score zero mutants. The daemon path now returns before
+  booting anything when the job list is empty (#76).
 - **A dead daemon ends the run instead of scoring the rest against it** — a
   daemon that dies while running one mutant was already handled: `DaemonClient`
   respawns and answers `error` for that mutant. But a daemon that could not come

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -74,7 +74,7 @@ module Mutineer
       # below only holds when fail-fast cannot race.
       worker_count = [config.jobs || 1, 1].max
       worker_count = 1 if config.fail_fast
-      worker_count = [worker_count, jobs.size].min if jobs.size.positive?
+      worker_count = [worker_count, jobs.size].min
 
       results =
         if worker_count > 1

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -44,6 +44,12 @@ module Mutineer
       jobs = Runner.filter_since(jobs, source_map, config) if config.since
       abs_tests = config.tests.map { |t| File.expand_path(t, config.project_root) }
 
+      # Nothing to mutate (`--since` matched no changed line, or every mutant is
+      # suppressed). Return before booting anything: the coverage daemon and the
+      # worker daemons below each boot the whole app, and README documents
+      # `--since origin/<base>` for PR CI, where a docs-only PR is routine.
+      return [AggregateResult.new(ignored_results), source_map] if jobs.empty?
+
       # Build the coverage map once (app-side). nil when the build fails: runners
       # fall back to the full --test set (and emit a stderr warning) rather than
       # mis-scoring everything as no_coverage.

--- a/lib/mutineer/daemon_backend.rb
+++ b/lib/mutineer/daemon_backend.rb
@@ -32,6 +32,10 @@ module Mutineer
     # {ExternalBackend::SMOKE_TIMEOUT}, which bounds a different thing.
     DEFAULT_TIMEOUT = 60
 
+    # The daemon's per-mutant tempfile, written into the source dir so
+    # require_relative resolves. Kept in step with DaemonServer#sweep_temps.
+    DAEMON_TEMP_GLOB = "mutineer_daemon*.rb"
+
     # Full daemon run: collect jobs, build the coverage map once, then execute
     # serially or across N worker daemons. Fail-fast forces serial so the survivor
     # set matches jobs 1.
@@ -48,7 +52,13 @@ module Mutineer
       # suppressed). Return before booting anything: the coverage daemon and the
       # worker daemons below each boot the whole app, and README documents
       # `--since origin/<base>` for PR CI, where a docs-only PR is routine.
-      return [AggregateResult.new(ignored_results), source_map] if jobs.empty?
+      if jobs.empty?
+        # The daemon sweeps orphaned temps at boot and nothing boots here, so sweep
+        # tool-side. A file a hard-killed run left in app/models breaks the app's own
+        # Zeitwerk boot, not just Mutineer's next run.
+        Runner.sweep_orphans(Runner.source_dirs(config), DAEMON_TEMP_GLOB)
+        return [AggregateResult.new(ignored_results), source_map]
+      end
 
       # Build the coverage map once (app-side). nil when the build fails: runners
       # fall back to the full --test set (and emit a stderr warning) rather than

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -357,14 +357,16 @@ module Mutineer
       config.sources.map { |f| File.dirname(File.expand_path(f, config.project_root)) }.uniq
     end
 
-    # Removes stale mutant tempfiles from the given directories.
+    # Removes stale mutant tempfiles from the given directories. The daemon writes a
+    # differently-named temp, so {DaemonBackend} passes its glob when it has to sweep
+    # tool-side (nothing boots on an empty run, so the daemon's own sweep never runs).
     #
-    # @api private
     # @param dirs [Array<String>] directories to sweep.
+    # @param glob [String] filename pattern to remove.
     # @return [void]
-    def self.sweep_orphans(dirs)
+    def self.sweep_orphans(dirs, glob = "mutineer_mutant*.rb")
       dirs.each do |dir|
-        Dir.glob(File.join(dir, "mutineer_mutant*.rb")).each do |f|
+        Dir.glob(File.join(dir, glob)).each do |f|
           File.unlink(f) rescue nil # rubocop:disable Style/RescueModifier
         end
       end

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -193,9 +193,7 @@ module Mutineer
       jobs = filter_since(jobs, source_map, config) if config.since
 
       # Nothing to mutate: return before the smoke check, which runs the whole
-      # --test set to calibrate a timeout no mutant would use. Mirrors the daemon
-      # path (#76). The in-process path cannot do this — it boots and builds
-      # coverage before collect_jobs, so it does not yet know the list is empty.
+      # --test set to calibrate a timeout no mutant would use (#76).
       return [AggregateResult.new(ignored_results), source_map] if jobs.empty?
 
       # Calibrate the per-mutant timeout from the clean run (a real suite far

--- a/lib/mutineer/runner.rb
+++ b/lib/mutineer/runner.rb
@@ -192,6 +192,12 @@ module Mutineer
       jobs, ignored_results, source_map = collect_jobs(config, operator_classes)
       jobs = filter_since(jobs, source_map, config) if config.since
 
+      # Nothing to mutate: return before the smoke check, which runs the whole
+      # --test set to calibrate a timeout no mutant would use. Mirrors the daemon
+      # path (#76). The in-process path cannot do this — it boots and builds
+      # coverage before collect_jobs, so it does not yet know the list is empty.
+      return [AggregateResult.new(ignored_results), source_map] if jobs.empty?
+
       # Calibrate the per-mutant timeout from the clean run (a real suite far
       # outlasts the 10s in-process fork budget), and abort if it is not green.
       # 3x the clean run, floor 30s, ceiling 300s: a heuristic. The floor covers

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -175,6 +175,23 @@ class DaemonBackendContractTest < Minitest::Test
     assert_match(/not running/, error.message)
   end
 
+  # `--since` matching nothing is the normal case for a docs-only PR, and README
+  # documents that flag for PR CI. Booting the app once for the coverage map and
+  # again per worker, to score zero mutants, is pure waste.
+  def test_an_empty_job_list_boots_nothing
+    Dir.mktmpdir("mutineer-empty") do |root|
+      config = Mutineer::Config.new(sources: [], tests: [], project_root: root,
+                                    framework: "minitest", jobs: 4)
+
+      Mutineer::DaemonClient.stub(:new, ->(**) { flunk "booted a daemon for zero jobs" }) do
+        aggregate, source_map = Mutineer::DaemonBackend.execute(config, [])
+
+        assert_equal 0, aggregate.total
+        assert_empty source_map
+      end
+    end
+  end
+
   # A daemon that dies before accepting the boot payload makes the write raise
   # Errno::EPIPE. Left as a SystemCallError it reaches the CLI as a usage error
   # (exit 2), which would tell CI the flags were wrong rather than the daemon died.

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -192,6 +192,21 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
+  # Same input, same answer on the other backend that can know before it pays: the
+  # smoke check runs the whole suite to calibrate a timeout no mutant would use.
+  def test_an_empty_job_list_skips_the_external_smoke_check
+    Dir.mktmpdir("mutineer-empty-ext") do |root|
+      config = Mutineer::Config.new(sources: [], tests: [], project_root: root,
+                                    framework: "minitest", test_command: "false")
+
+      Mutineer::ExternalBackend.stub(:smoke_check!, ->(*) { flunk "ran the suite for zero jobs" }) do
+        aggregate, = Mutineer::Runner.execute(config)
+
+        assert_equal 0, aggregate.total
+      end
+    end
+  end
+
   # A daemon that dies before accepting the boot payload makes the write raise
   # Errno::EPIPE. Left as a SystemCallError it reaches the CLI as a usage error
   # (exit 2), which would tell CI the flags were wrong rather than the daemon died.

--- a/test/daemon_backend_contract_test.rb
+++ b/test/daemon_backend_contract_test.rb
@@ -192,6 +192,28 @@ class DaemonBackendContractTest < Minitest::Test
     end
   end
 
+  # The daemon sweeps its orphaned temps at boot. Nothing boots on an empty run, so
+  # a file left by a hard-killed run would survive — and one sitting in app/models
+  # breaks the app's own Zeitwerk boot, not just the next Mutineer run.
+  def test_an_empty_job_list_still_sweeps_orphaned_daemon_temps
+    Dir.mktmpdir("mutineer-sweep") do |root|
+      FileUtils.mkdir_p(File.join(root, "app"))
+      source = File.join(root, "app/order.rb")
+      File.binwrite(source, SOURCE)
+      orphan = File.join(root, "app/mutineer_daemon20260101-1-abcdef.rb")
+      File.binwrite(orphan, "class Order; end\n")
+
+      config = Mutineer::Config.new(sources: [source], tests: [], project_root: root,
+                                    framework: "minitest", only: ["NoSuchMethod"])
+
+      Mutineer::DaemonClient.stub(:new, ->(**) { flunk "booted a daemon for zero jobs" }) do
+        Mutineer::DaemonBackend.execute(config, [])
+      end
+
+      refute_path_exists orphan, "a zero-job run must still clear orphaned daemon temps"
+    end
+  end
+
   # Same input, same answer on the other backend that can know before it pays: the
   # smoke check runs the whole suite to calibrate a timeout no mutant would use.
   def test_an_empty_job_list_skips_the_external_smoke_check


### PR DESCRIPTION
Closes #76. Found by the adversarial reviewer during the #58 gate.

## What

`mutineer run --rails --daemon --since origin/main --jobs 4` on a PR that changes no mutatable line booted the app **five times** to score zero mutants: once for the coverage map, then once per worker. Both backends that can know the job list is empty before paying now return immediately.

## Why it matters

README documents `--since origin/${{ github.base_ref }}` as the PR-CI invocation, so a docs-only or test-only PR is the normal case, not an edge case. On a real Rails app that was minutes of boots to produce an empty report.

The worker cap `[worker_count, jobs.size].min` is skipped by its own `positive?` guard, so an empty job list left `worker_count` at whatever `--jobs` the user passed.

## Scope

- **`--daemon`** — returns before `build_coverage_map`, so nothing boots.
- **`--test-command`** — returns before `ExternalBackend.smoke_check!`, which otherwise runs the whole `--test` set to calibrate a per-mutant timeout no mutant would use. The predictability lens pointed out the waste was never daemon-specific, and leaving it would have made the two backends answer the same input differently.
- **in-process** — unchanged, and cannot do this. It boots and builds coverage *before* `collect_jobs`, so at that point it does not yet know the list is empty. Reordering would fight the constraint that `Coverage.start` must precede the boot require.

## The trade-off, decided deliberately

A zero-job run used to reach `DaemonClient.start` (or the smoke check), so an app that could not boot, an invalid `--test-command`, or a red unmutated suite failed that run with exit 1. Nothing runs now, so it exits 0.

Cubic flagged this at P1 on both backends, as masking a real signal. The predictability lens flagged the same thing at P3 and called the new behaviour the defensible one. It is a product question rather than a bug, so it went to the maintainer, who chose to skip: Mutineer was asked about changed lines, there are none, and the repo's own test job already covers whether the app boots. It is stated in the CHANGELOG rather than left for someone to discover.

## Testing

Two tests, each verified to fail when its guard is removed:

- `test_an_empty_job_list_boots_nothing` — flunks if any `DaemonClient` is constructed
- `test_an_empty_job_list_skips_the_external_smoke_check` — flunks if the smoke check runs

Also checked by hand: the early return skips no cleanup (`FileSwap.restore_orphans` already ran before `collect_jobs`, and nothing has been mutated), and the returned aggregate is identical to what the full path builds for zero jobs, since `results` is empty there.

`rake test` 420 runs / 1203 assertions, `rake test:daemon` 14 runs, `yard:strict` 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfCKGYtEpcYLtp71Rsqf3h
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return early when there are no mutation jobs so docs-only or test-only PRs finish instantly. Also sweep orphaned daemon temp files so empty runs don’t break app boot.

- **Bug Fixes**
  - `--daemon`: return before building the coverage map or starting workers when the job list is empty.
  - Sweep orphaned `mutineer_daemon*.rb` before returning to prevent Zeitwerk boot errors on empty runs.
  - External `--test-command`: return before `ExternalBackend.smoke_check!` if the job list is empty.
  - Drop the dead worker-cap guard (`jobs.size.positive?`) since the early return guarantees a non-empty list before capping.
  - In-process path unchanged; it must boot before collecting jobs.

- **Migration**
  - Zero-job `--daemon` runs now exit 0 (no work) instead of 1 if the app cannot boot.

<sup>Written for commit 0c86d805428b0d6f9e1006b1d80e64d998692aca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

