### PR TITLE
fix: --threshold gates on the run being complete, not just its score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`--threshold` now gates on the run being complete, not just its score** — a
+  score is `killed / (killed + survived)`, so mutants that error, time out or come
+  back uncapturable are excluded from the denominator: a broken harness *raised*
+  the score instead of lowering it. Ninety errored mutants and ten that ran (nine
+  killed) reported 90% and exited 0, so CI could not tell a complete run from a
+  mostly-broken one. Past 10% of attempted mutants producing no verdict, a positive
+  `--threshold` now exits 1 whatever the score, and the human report says why. A
+  few flaky mutants in a large run still pass (#78).
+
+### Added
+- **`errored[]` in the JSON report** (`schema_version` 1.2) — the per-mutant list
+  of everything attempted that produced no verdict, with `status` and the `details`
+  explaining the cause. `Result#details` was built and rendered nowhere before, so a
+  daemon crash reached the user as nothing but a larger errored count (#78).
+
 ## [0.11.3] - 2026-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,17 @@ All notable changes to this project are documented here. The format is based on
   the score instead of lowering it. Ninety errored mutants and ten that ran (nine
   killed) reported 90% and exited 0, so CI could not tell a complete run from a
   mostly-broken one. Past 10% of attempted mutants producing no verdict, a positive
-  `--threshold` now exits 1 whatever the score, and the human report says why. A
-  few flaky mutants in a large run still pass (#78).
+  `--threshold` now exits 1 whatever the score, and the report says which states
+  broke, on every `--format`. A single bad mutant never trips it, however small the
+  run, so a `--since` PR with a handful of mutants keeps its flake tolerance (#78).
 
 ### Added
-- **`errored[]` in the JSON report** (`schema_version` 1.2) — the per-mutant list
-  of everything attempted that produced no verdict, with `status` and the `details`
-  explaining the cause. `Result#details` was built and rendered nowhere before, so a
-  daemon crash reached the user as nothing but a larger errored count (#78).
+- **`no_verdict[]` in the JSON report** (`schema_version` 1.2) — every attempted
+  mutant that produced no verdict, with its `status` and, where there is one, the
+  `details` explaining the cause. `Result#details` was built and rendered in no
+  format at all, so a daemon crash reached the user as nothing but a larger errored
+  count. `summary` gains `attempted` and `no_verdict`, the two figures the
+  completeness gate is computed from (#78).
 
 ## [0.11.3] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 |------|---------|
 | `--test FILE` | Test file covering the sources (repeatable) |
 | `--operators LIST` | Comma-separated operator names (default: the Tier-1 set) |
-| `--threshold FLOAT` | Exit 1 when the score is below FLOAT, or when more than 10% of attempted mutants produced no verdict (default: 0 = off) |
+| `--threshold FLOAT` | Exit 1 when the score is below FLOAT, or when more than one mutant produced no verdict and they exceed 10% of those attempted (default: 0 = off) |
 | `--only NAME` | Restrict to one fully-qualified subject, e.g. `Calculator#add` |
 | `--framework NAME` | `minitest` (default) or `rspec`; auto-detected as rspec when most `--test` files end in `_spec.rb` |
 | `--since REF` | Only mutate lines changed since git `REF` (e.g. `origin/main`) — ideal for PR CI |
@@ -70,7 +70,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no threshold set) |
-| `1` | Score below threshold, more than 10% of attempted mutants with no verdict, a `--baseline` regression, or a runtime error |
+| `1` | Score below threshold, more than one mutant produced no verdict and they exceed 10% of those attempted, a `--baseline` regression, or a runtime error |
 | `2` | Usage / invalid-flag error |
 
 ### Operators

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no threshold set) |
-| `1` | Survivors below threshold, or a runtime error |
+| `1` | Score below threshold, more than 10% of attempted mutants with no verdict, a `--baseline` regression, or a runtime error |
 | `2` | Usage / invalid-flag error |
 
 ### Operators

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 |------|---------|
 | `--test FILE` | Test file covering the sources (repeatable) |
 | `--operators LIST` | Comma-separated operator names (default: the Tier-1 set) |
-| `--threshold FLOAT` | Exit 1 when the score is below FLOAT (default: 0 = off) |
+| `--threshold FLOAT` | Exit 1 when the score is below FLOAT, or when more than 10% of attempted mutants produced no verdict (default: 0 = off) |
 | `--only NAME` | Restrict to one fully-qualified subject, e.g. `Calculator#add` |
 | `--framework NAME` | `minitest` (default) or `rspec`; auto-detected as rspec when most `--test` files end in `_spec.rb` |
 | `--since REF` | Only mutate lines changed since git `REF` (e.g. `origin/main`) — ideal for PR CI |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 |------|---------|
 | `--test FILE` | Test file covering the sources (repeatable) |
 | `--operators LIST` | Comma-separated operator names (default: the Tier-1 set) |
-| `--threshold FLOAT` | Exit 1 when the score is below FLOAT, or when more than one mutant produced no verdict and they exceed 10% of those attempted (default: 0 = off) |
+| `--threshold FLOAT` | Exit 1 when the score is below FLOAT, or when nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted (default: 0 = off) |
 | `--only NAME` | Restrict to one fully-qualified subject, e.g. `Calculator#add` |
 | `--framework NAME` | `minitest` (default) or `rspec`; auto-detected as rspec when most `--test` files end in `_spec.rb` |
 | `--since REF` | Only mutate lines changed since git `REF` (e.g. `origin/main`) — ideal for PR CI |
@@ -70,7 +70,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no threshold set) |
-| `1` | Score below threshold, more than one mutant produced no verdict and they exceed 10% of those attempted, a `--baseline` regression, or a runtime error |
+| `1` | Score below threshold, nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted, a `--baseline` regression, or a runtime error |
 | `2` | Usage / invalid-flag error |
 
 ### Operators

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ""
   threshold:
-    description: "Fail (exit 1) when the mutation score is below this value, or when more than 10% of attempted mutants produced no verdict (0 = off)."
+    description: "Fail (exit 1) when the mutation score is below this value, or when more than one mutant produced no verdict and they exceed 10% of those attempted (0 = off)."
     required: false
     default: ""
   baseline:

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ""
   threshold:
-    description: "Fail (exit 1) when the mutation score is below this value, or when more than one mutant produced no verdict and they exceed 10% of those attempted (0 = off)."
+    description: "Fail (exit 1) when the mutation score is below this value, or when nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted (0 = off)."
     required: false
     default: ""
   baseline:

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ""
   threshold:
-    description: "Fail (exit 1) when the mutation score is below this value (0 = off)."
+    description: "Fail (exit 1) when the mutation score is below this value, or when more than 10% of attempted mutants produced no verdict (0 = off)."
     required: false
     default: ""
   baseline:
@@ -89,7 +89,7 @@ inputs:
 
 outputs:
   exit-code:
-    description: "The exit code returned by mutineer (0 pass, 1 below-threshold/regressed, 2 usage)."
+    description: "The exit code returned by mutineer (0 pass, 1 below-threshold/incomplete-run/regressed, 2 usage)."
     value: ${{ steps.run.outputs.exit-code }}
   report:
     description: "Path to the written report file, when the `output` input is set."

--- a/docs/agentic-coding.md
+++ b/docs/agentic-coding.md
@@ -124,7 +124,7 @@ human review / suppression rather than looping forever.
 | Code | Pipeline action |
 |------|-----------------|
 | `0` | Pass — score ≥ threshold and no baseline regression. |
-| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than one mutant produced no verdict and they exceed 10% of those attempted), or a regression was introduced. Tell them apart with `summary.score`, `summary.no_verdict / summary.attempted`, and `baseline.regressed`. |
+| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted), or a regression was introduced. Tell them apart with `summary.score`, `summary.no_verdict / summary.attempted`, and `baseline.regressed`. |
 | `2` | Fail the *job* differently — this is a misinvocation (bad flag/path), not a test-quality signal. |
 
 Branch on these directly; never scrape the human report. The JSON `summary` and `baseline` blocks carry

--- a/docs/agentic-coding.md
+++ b/docs/agentic-coding.md
@@ -124,7 +124,7 @@ human review / suppression rather than looping forever.
 | Code | Pipeline action |
 |------|-----------------|
 | `0` | Pass — score ≥ threshold and no baseline regression. |
-| `1` | Fail the check — tests are too weak (below threshold) or a regression was introduced. |
+| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than 10% of attempted mutants produced no verdict), or a regression was introduced. Tell them apart with `summary.score`, `summary.no_verdict / summary.attempted`, and `baseline.regressed`. |
 | `2` | Fail the *job* differently — this is a misinvocation (bad flag/path), not a test-quality signal. |
 
 Branch on these directly; never scrape the human report. The JSON `summary` and `baseline` blocks carry

--- a/docs/agentic-coding.md
+++ b/docs/agentic-coding.md
@@ -124,7 +124,7 @@ human review / suppression rather than looping forever.
 | Code | Pipeline action |
 |------|-----------------|
 | `0` | Pass — score ≥ threshold and no baseline regression. |
-| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than 10% of attempted mutants produced no verdict), or a regression was introduced. Tell them apart with `summary.score`, `summary.no_verdict / summary.attempted`, and `baseline.regressed`. |
+| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than one mutant produced no verdict and they exceed 10% of those attempted), or a regression was introduced. Tell them apart with `summary.score`, `summary.no_verdict / summary.attempted`, and `baseline.regressed`. |
 | `2` | Fail the *job* differently — this is a misinvocation (bad flag/path), not a test-quality signal. |
 
 Branch on these directly; never scrape the human report. The JSON `summary` and `baseline` blocks carry

--- a/docs/json-schema.html
+++ b/docs/json-schema.html
@@ -63,13 +63,13 @@
     </aside>
 
     <article class="prose">
-      <span class="eyebrow"><span class="dot" aria-hidden="true"></span> Reference · schema_version 1.1</span>
+      <span class="eyebrow"><span class="dot" aria-hidden="true"></span> Reference · schema_version 1.2</span>
       <h1>JSON report schema reference</h1>
       <p class="doc-lede"><code>mutineer run --format json</code> emits a single JSON object (one line, newline-terminated) describing the whole run. It is the <strong>machine-readable contract</strong> for tooling — CI gates, dashboards, and AI coding agents.</p>
       <p>Output is deterministic: arrays are sorted by <code>(file, line, operator)</code> regardless of <code>--jobs</code> worker finish order, so two runs of the same inputs produce byte-identical output.</p>
 
       <h2 id="versioning">Versioning contract</h2>
-      <p>The top-level <code>schema_version</code> (a string, e.g. <code>"1.1"</code>) follows these rules:</p>
+      <p>The top-level <code>schema_version</code> (a string, e.g. <code>"1.2"</code>) follows these rules:</p>
       <ul>
         <li><strong>Additive changes</strong> (new keys on existing objects, new top-level keys) bump the <strong>minor</strong> version (<code>1.0</code> → <code>1.1</code>). Existing keys keep their meaning. Consumers MUST ignore unknown keys.</li>
         <li><strong>Breaking changes</strong> (renaming/removing a key, changing a value's type or meaning) bump the <strong>major</strong> version (<code>1.x</code> → <code>2.0</code>).</li>
@@ -78,11 +78,12 @@
 
       <h2 id="shape">Top-level shape</h2>
       <pre><code>{
-  <span class="p">"schema_version"</span>: <span class="k">"1.1"</span>,
+  <span class="p">"schema_version"</span>: <span class="k">"1.2"</span>,
   <span class="p">"summary"</span>:      { <span class="c">/* run totals, see below */</span> },
   <span class="p">"survivors"</span>:    [ <span class="c">/* mutants the suite failed to catch — the actionable gaps */</span> ],
   <span class="p">"no_coverage"</span>:  [ <span class="c">/* mutants on lines no test exercises */</span> ],
   <span class="p">"uncapturable"</span>: [ <span class="c">/* mutants whose would-be test errored during coverage capture */</span> ],
+  <span class="p">"no_verdict"</span>:   [ <span class="c">/* attempted mutants that produced no verdict: errored, timeout, uncapturable */</span> ],
   <span class="p">"ignored"</span>:      [ <span class="c">/* mutants the user suppressed (equivalent mutants) */</span> ],
   <span class="p">"per_source"</span>:   [ <span class="c">/* per-file roll-up */</span> ],
   <span class="p">"baseline"</span>:     { <span class="c">/* present ONLY with --baseline: the delta vs a prior run */</span> }

--- a/docs/json-schema.html
+++ b/docs/json-schema.html
@@ -103,6 +103,8 @@
             <tr><td class="op">errored</td><td class="rule">int</td><td>Mutants whose run raised (excluded).</td></tr>
             <tr><td class="op">timeout</td><td class="rule">int</td><td>Mutants whose run exceeded the per-mutant timeout (excluded).</td></tr>
             <tr><td class="op">ignored</td><td class="rule">int</td><td>Mutants suppressed via <code>#&nbsp;mutineer:disable-line</code> or <code>.mutineer.yml</code> <code>ignore:</code> (excluded).</td></tr>
+            <tr><td class="op">attempted</td><td class="rule">int</td><td>Mutants actually run: <code>killed + survived + no_verdict</code>. <strong>Not</strong> <code>total</code> — no-coverage, skipped and ignored mutants were never attempted.</td></tr>
+            <tr><td class="op">no_verdict</td><td class="rule">int</td><td>Attempted mutants that produced no verdict: <code>errored + timeout + uncapturable</code>. The completeness gate is <code>no_verdict / attempted</code>.</td></tr>
             <tr><td class="op">score</td><td class="rule">float | null</td><td><code>killed / (killed + survived) * 100</code>, rounded. <strong><code>null</code></strong> when the denominator is empty (no covered mutants) — never <code>0.0</code>.</td></tr>
           </tbody>
         </table>
@@ -127,6 +129,10 @@
 
       <h2 id="other-statuses"><code>no_coverage[]</code> and <code>uncapturable[]</code> (array of object)</h2>
       <p>Both use the lean shape <code>{ subject, file, line }</code>. <code>no_coverage</code> is a genuine coverage gap; <code>uncapturable</code> means the test that should cover the line errored while capturing coverage (fix the harness, not the test).</p>
+
+      <h2 id="no-verdict"><code>no_verdict[]</code> (array of object)</h2>
+      <p>Every mutant that was attempted and produced no verdict: <code>{ subject, file, line, id, status, details }</code>. <code>status</code> is <code>"error"</code>, <code>"timeout"</code> or <code>"uncapturable"</code>, and its length equals <code>summary.no_verdict</code>. <code>details</code> carries the cause for <code>"error"</code>; it is <code>null</code> for the other two, where the status is the whole story.</p>
+      <p>A failure before the mutant could be forked has no subject, so <code>subject</code>, <code>file</code>, <code>line</code> and <code>id</code> are <code>null</code> on that entry — <code>id</code> is therefore not a reliable join key here, unlike in <code>survivors[]</code>. These mutants are excluded from the score's denominator, so a broken harness raises the score rather than lowering it; that is why <code>--threshold</code> gates on completeness as well.</p>
 
       <h2 id="ignored"><code>ignored[]</code> (array of object)</h2>
       <p>Suppressed (equivalent) mutants, so you can audit what's silenced: <code>{ subject, file, line, operator, token, id }</code>.</p>
@@ -156,7 +162,7 @@
           <thead><tr><th scope="col">Code</th><th scope="col">Meaning</th></tr></thead>
           <tbody>
             <tr><td class="op">0</td><td>Score ≥ threshold (or no gate) <strong>and</strong> no baseline regression.</td></tr>
-            <tr><td class="op">1</td><td>Score below <code>--threshold</code>, OR a <code>--baseline</code> regression, OR a runtime error.</td></tr>
+            <tr><td class="op">1</td><td>Score below <code>--threshold</code>, OR more than one mutant produced no verdict and they exceed 10% of those attempted, OR a <code>--baseline</code> regression, OR a runtime error.</td></tr>
             <tr><td class="op">2</td><td>Usage / invalid-flag error (mistyped flag, bad path, unreadable baseline).</td></tr>
           </tbody>
         </table>

--- a/docs/json-schema.html
+++ b/docs/json-schema.html
@@ -162,7 +162,7 @@
           <thead><tr><th scope="col">Code</th><th scope="col">Meaning</th></tr></thead>
           <tbody>
             <tr><td class="op">0</td><td>Score ≥ threshold (or no gate) <strong>and</strong> no baseline regression.</td></tr>
-            <tr><td class="op">1</td><td>Score below <code>--threshold</code>, OR more than one mutant produced no verdict and they exceed 10% of those attempted, OR a <code>--baseline</code> regression, OR a runtime error.</td></tr>
+            <tr><td class="op">1</td><td>Score below <code>--threshold</code>, OR nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted, OR a <code>--baseline</code> regression, OR a runtime error.</td></tr>
             <tr><td class="op">2</td><td>Usage / invalid-flag error (mistyped flag, bad path, unreadable baseline).</td></tr>
           </tbody>
         </table>

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -20,11 +20,12 @@ A consumer should accept any `1.x` document and read only the keys it knows.
 
 ```jsonc
 {
-  "schema_version": "1.1",
+  "schema_version": "1.2",
   "summary":      { /* run totals, see below */ },
   "survivors":    [ /* mutants the suite failed to catch — the actionable gaps */ ],
   "no_coverage":  [ /* mutants on lines no test exercises */ ],
   "uncapturable": [ /* mutants whose would-be test errored during coverage capture */ ],
+  "errored":      [ /* mutants that were attempted and produced no verdict */ ],
   "ignored":      [ /* mutants the user suppressed (equivalent mutants) */ ],
   "per_source":   [ /* per-file roll-up */ ],
   "baseline":     { /* present ONLY with --baseline: the delta vs a prior run */ }
@@ -65,6 +66,20 @@ Each surviving mutant — the records an agent or reviewer acts on:
 Both use the lean shape `{ subject, file, line }`. `no_coverage` is a genuine coverage gap; `uncapturable`
 means the test that should cover the line errored while capturing coverage (fix the harness, not the test).
 
+### `errored[]` (array of object)
+
+Mutants that were attempted but produced no verdict: `{ subject, file, line, id, status, details }`.
+`status` is `"error"` or `"timeout"`, and `details` carries the cause (a daemon crash, for instance).
+Its length equals `summary.errored + summary.timeout`.
+
+A failure before the mutant could be forked has no subject or mutation, so `subject`, `file` and `line`
+are `null` on that entry — it still appears, because the counts must reconcile.
+
+Read this array when the score looks better than you expect: mutants that error are excluded from the
+score's denominator, so a broken harness raises the score rather than lowering it. Under a positive
+`--threshold`, a run where more than 10% of attempted mutants produced no verdict exits 1 regardless of
+the score, for that reason.
+
 ### `ignored[]` (array of object)
 
 Suppressed (equivalent) mutants, so you can audit what's silenced: `{ subject, file, line, operator, token, id }`.
@@ -91,8 +106,14 @@ The delta versus the prior `--format json` report, matched by stable `id`:
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no gate) **and** no baseline regression. |
-| `1` | Score below `--threshold`, OR a `--baseline` regression, OR a runtime error. |
+| `1` | Score below `--threshold`, OR more than 10% of attempted mutants produced no verdict, OR a `--baseline` regression, OR a runtime error. |
 | `2` | Usage / invalid-flag error (mistyped flag, bad path, unreadable baseline). |
+
+Under a positive `--threshold`, a run is gated on being complete as well as on its score. Errored,
+timed-out and uncapturable mutants are excluded from the denominator, so a broken harness inflates the
+score instead of lowering it; past 10% of attempted mutants, the score is treated as covering too little
+of the run to gate on. Read `errored[]` to see what failed. A run where *nothing* was scored and
+something broke already exits 1.
 
 `--threshold` and `--baseline` are independent gates OR'd together (the worse code wins); usage errors (2)
 always win. This lets a pipeline distinguish "tests too weak" (1) from "you invoked me wrong" (2).

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -113,13 +113,15 @@ The delta versus the prior `--format json` report, matched by stable `id`:
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no gate) **and** no baseline regression. |
-| `1` | Score below `--threshold`, OR more than one mutant produced no verdict and they exceed 10% of those attempted, OR a `--baseline` regression, OR a runtime error. |
+| `1` | Score below `--threshold`, OR nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted, OR a `--baseline` regression, OR a runtime error. |
 | `2` | Usage / invalid-flag error (mistyped flag, bad path, unreadable baseline). |
 
 Under a positive `--threshold`, a run is gated on being complete as well as on its score. Mutants with no
 verdict are excluded from the score's denominator, so a broken harness inflates the score instead of
 lowering it. Past 10% of attempted mutants — and never for a single one, however small the run — the
-score is treated as covering too little of the run to gate on. Read `no_verdict[]` to see what failed.
+score is treated as covering too little of the run to gate on. The floor applies only when there *is* a
+score: a run where nothing could be scored at all fails on a single broken mutant, because there is no
+score to weigh it against. Read `no_verdict[]` to see what failed.
 A run where *nothing* was scored and something broke already exits 1.
 
 `--threshold` and `--baseline` are independent gates OR'd together (the worse code wins); usage errors (2)

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -7,7 +7,7 @@ worker finish order, so two runs of the same inputs produce byte-identical outpu
 
 ## Versioning contract
 
-The top-level `schema_version` (a string, e.g. `"1.1"`) follows these rules:
+The top-level `schema_version` (a string, e.g. `"1.2"`) follows these rules:
 
 - **Additive changes** (new keys on existing objects, new top-level keys) bump the **minor** version
   (`1.0` → `1.1`). Existing keys keep their meaning. Consumers MUST ignore unknown keys.
@@ -113,7 +113,7 @@ The delta versus the prior `--format json` report, matched by stable `id`:
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no gate) **and** no baseline regression. |
-| `1` | Score below `--threshold`, OR more than 10% of attempted mutants produced no verdict, OR a `--baseline` regression, OR a runtime error. |
+| `1` | Score below `--threshold`, OR more than one mutant produced no verdict and they exceed 10% of those attempted, OR a `--baseline` regression, OR a runtime error. |
 | `2` | Usage / invalid-flag error (mistyped flag, bad path, unreadable baseline). |
 
 Under a positive `--threshold`, a run is gated on being complete as well as on its score. Mutants with no

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -25,7 +25,7 @@ A consumer should accept any `1.x` document and read only the keys it knows.
   "survivors":    [ /* mutants the suite failed to catch — the actionable gaps */ ],
   "no_coverage":  [ /* mutants on lines no test exercises */ ],
   "uncapturable": [ /* mutants whose would-be test errored during coverage capture */ ],
-  "errored":      [ /* mutants that were attempted and produced no verdict */ ],
+  "no_verdict":   [ /* mutants that were attempted and produced no verdict */ ],
   "ignored":      [ /* mutants the user suppressed (equivalent mutants) */ ],
   "per_source":   [ /* per-file roll-up */ ],
   "baseline":     { /* present ONLY with --baseline: the delta vs a prior run */ }
@@ -45,6 +45,8 @@ A consumer should accept any `1.x` document and read only the keys it knows.
 | `errored` | int | Mutants whose run raised (excluded). |
 | `timeout` | int | Mutants whose run exceeded the per-mutant timeout (excluded). |
 | `ignored` | int | Mutants suppressed via `# mutineer:disable-line` or `.mutineer.yml` `ignore:` (excluded). |
+| `attempted` | int | Mutants actually run: `killed + survived + no_verdict`. **Not** `total` — no-coverage, skipped and ignored mutants were never attempted. |
+| `no_verdict` | int | Attempted mutants that produced no verdict: `errored + timeout + uncapturable`. The completeness gate is `no_verdict / attempted`. |
 | `score` | float \| null | `killed / (killed + survived) * 100`, rounded. **`null`** when the denominator is empty (no covered mutants) — never `0.0`. |
 
 ### `survivors[]` (array of object)
@@ -66,19 +68,24 @@ Each surviving mutant — the records an agent or reviewer acts on:
 Both use the lean shape `{ subject, file, line }`. `no_coverage` is a genuine coverage gap; `uncapturable`
 means the test that should cover the line errored while capturing coverage (fix the harness, not the test).
 
-### `errored[]` (array of object)
+### `no_verdict[]` (array of object)
 
-Mutants that were attempted but produced no verdict: `{ subject, file, line, id, status, details }`.
-`status` is `"error"` or `"timeout"`, and `details` carries the cause (a daemon crash, for instance).
-Its length equals `summary.errored + summary.timeout`.
+Every mutant that was attempted and produced no verdict: `{ subject, file, line, id, status, details }`.
+`status` is `"error"`, `"timeout"` or `"uncapturable"`, and its length equals `summary.no_verdict`.
 
-A failure before the mutant could be forked has no subject or mutation, so `subject`, `file` and `line`
-are `null` on that entry — it still appears, because the counts must reconcile.
+`details` carries the cause where there is one. For `"error"` that is the failure (a daemon crash, say);
+for `"timeout"` and `"uncapturable"` it is `null`, because the status is the whole story.
 
-Read this array when the score looks better than you expect: mutants that error are excluded from the
-score's denominator, so a broken harness raises the score rather than lowering it. Under a positive
-`--threshold`, a run where more than 10% of attempted mutants produced no verdict exits 1 regardless of
-the score, for that reason.
+A failure before the mutant could be forked has no subject or mutation, so `subject`, `file`, `line` and
+`id` are `null` on that entry. It still appears, because the counts must reconcile — but that means `id`
+is not a reliable join key here, unlike in `survivors[]` and `ignored[]`.
+
+Uncapturable mutants appear both here and in `uncapturable[]`, which keeps its lean shape for consumers
+that already read it.
+
+Read this array when the score looks better than you expect: these mutants are excluded from the score's
+denominator, so a broken harness raises the score rather than lowering it. That is why `--threshold`
+gates on completeness as well (see Exit codes).
 
 ### `ignored[]` (array of object)
 
@@ -109,11 +116,15 @@ The delta versus the prior `--format json` report, matched by stable `id`:
 | `1` | Score below `--threshold`, OR more than 10% of attempted mutants produced no verdict, OR a `--baseline` regression, OR a runtime error. |
 | `2` | Usage / invalid-flag error (mistyped flag, bad path, unreadable baseline). |
 
-Under a positive `--threshold`, a run is gated on being complete as well as on its score. Errored,
-timed-out and uncapturable mutants are excluded from the denominator, so a broken harness inflates the
-score instead of lowering it; past 10% of attempted mutants, the score is treated as covering too little
-of the run to gate on. Read `errored[]` to see what failed. A run where *nothing* was scored and
-something broke already exits 1.
+Under a positive `--threshold`, a run is gated on being complete as well as on its score. Mutants with no
+verdict are excluded from the score's denominator, so a broken harness inflates the score instead of
+lowering it. Past 10% of attempted mutants — and never for a single one, however small the run — the
+score is treated as covering too little of the run to gate on. Read `no_verdict[]` to see what failed.
+A run where *nothing* was scored and something broke already exits 1.
 
 `--threshold` and `--baseline` are independent gates OR'd together (the worse code wins); usage errors (2)
-always win. This lets a pipeline distinguish "tests too weak" (1) from "you invoked me wrong" (2).
+always win. Exit 2 still means "you invoked me wrong". Exit 1 now covers three distinct situations —
+tests too weak, the run did not complete, or a baseline regression — and they are not distinguishable
+from the exit code alone. Tell them apart from the JSON: compare `summary.score` against your threshold,
+`summary.no_verdict / summary.attempted` against 10%, and `baseline.regressed`. A run that failed only on
+completeness is the one worth retrying rather than blaming on the tests.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -79,7 +79,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no threshold set) |
-| `1` | Survivors below threshold, or a runtime error |
+| `1` | Score below threshold, more than 10% of attempted mutants with no verdict, a `--baseline` regression, or a runtime error |
 | `2` | Usage / invalid-flag error |
 
 ### Operators
@@ -387,7 +387,7 @@ human review / suppression rather than looping forever.
 | Code | Pipeline action |
 |------|-----------------|
 | `0` | Pass — score ≥ threshold and no baseline regression. |
-| `1` | Fail the check — tests are too weak (below threshold) or a regression was introduced. |
+| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than 10% of attempted mutants produced no verdict), or a regression was introduced. |
 | `2` | Fail the *job* differently — this is a misinvocation (bad flag/path), not a test-quality signal. |
 
 Branch on these directly; never scrape the human report. The JSON `summary` and `baseline` blocks carry
@@ -404,7 +404,7 @@ worker finish order, so two runs of the same inputs produce byte-identical outpu
 
 ## Versioning contract
 
-The top-level `schema_version` (a string, e.g. `"1.1"`) follows these rules:
+The top-level `schema_version` (a string, e.g. `"1.2"`) follows these rules:
 
 - **Additive changes** (new keys on existing objects, new top-level keys) bump the **minor** version
   (`1.0` → `1.1`). Existing keys keep their meaning. Consumers MUST ignore unknown keys.
@@ -417,11 +417,12 @@ A consumer should accept any `1.x` document and read only the keys it knows.
 
 ```jsonc
 {
-  "schema_version": "1.1",
+  "schema_version": "1.2",
   "summary":      { /* run totals, see below */ },
   "survivors":    [ /* mutants the suite failed to catch — the actionable gaps */ ],
   "no_coverage":  [ /* mutants on lines no test exercises */ ],
   "uncapturable": [ /* mutants whose would-be test errored during coverage capture */ ],
+  "no_verdict":   [ /* attempted mutants that produced no verdict: errored, timeout, uncapturable */ ],
   "ignored":      [ /* mutants the user suppressed (equivalent mutants) */ ],
   "per_source":   [ /* per-file roll-up */ ],
   "baseline":     { /* present ONLY with --baseline: the delta vs a prior run */ }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -79,7 +79,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no threshold set) |
-| `1` | Score below threshold, more than one mutant produced no verdict and they exceed 10% of those attempted, a `--baseline` regression, or a runtime error |
+| `1` | Score below threshold, nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted, a `--baseline` regression, or a runtime error |
 | `2` | Usage / invalid-flag error |
 
 ### Operators
@@ -387,7 +387,7 @@ human review / suppression rather than looping forever.
 | Code | Pipeline action |
 |------|-----------------|
 | `0` | Pass — score ≥ threshold and no baseline regression. |
-| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than one mutant produced no verdict and they exceed 10% of those attempted), or a regression was introduced. |
+| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (nothing could be scored and something broke, or more than one mutant produced no verdict and they exceed 10% of those attempted), or a regression was introduced. |
 | `2` | Fail the *job* differently — this is a misinvocation (bad flag/path), not a test-quality signal. |
 
 Branch on these directly; never scrape the human report. The JSON `summary` and `baseline` blocks carry

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -79,7 +79,7 @@ mutineer run lib/calculator.rb --test test/calculator_test.rb --threshold 90
 | Code | Meaning |
 |------|---------|
 | `0` | Score ≥ threshold (or no threshold set) |
-| `1` | Score below threshold, more than 10% of attempted mutants with no verdict, a `--baseline` regression, or a runtime error |
+| `1` | Score below threshold, more than one mutant produced no verdict and they exceed 10% of those attempted, a `--baseline` regression, or a runtime error |
 | `2` | Usage / invalid-flag error |
 
 ### Operators
@@ -387,7 +387,7 @@ human review / suppression rather than looping forever.
 | Code | Pipeline action |
 |------|-----------------|
 | `0` | Pass — score ≥ threshold and no baseline regression. |
-| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than 10% of attempted mutants produced no verdict), or a regression was introduced. |
+| `1` | Fail the check — tests are too weak (below threshold), the run did not complete (more than one mutant produced no verdict and they exceed 10% of those attempted), or a regression was introduced. |
 | `2` | Fail the *job* differently — this is a misinvocation (bad flag/path), not a test-quality signal. |
 
 Branch on these directly; never scrape the human report. The JSON `summary` and `baseline` blocks carry
@@ -442,6 +442,8 @@ A consumer should accept any `1.x` document and read only the keys it knows.
 | `errored` | int | Mutants whose run raised (excluded). |
 | `timeout` | int | Mutants whose run exceeded the per-mutant timeout (excluded). |
 | `ignored` | int | Mutants suppressed via `# mutineer:disable-line` or `.mutineer.yml` `ignore:` (excluded). |
+| `attempted` | int | Mutants actually run: `killed + survived + no_verdict`. **Not** `total` — no-coverage, skipped and ignored mutants were never attempted. |
+| `no_verdict` | int | Attempted mutants that produced no verdict: `errored + timeout + uncapturable`. The completeness gate is `no_verdict / attempted`. |
 | `score` | float \| null | `killed / (killed + survived) * 100`, rounded. **`null`** when the denominator is empty (no covered mutants) — never `0.0`. |
 
 ### `survivors[]` (array of object)
@@ -462,6 +464,17 @@ Each surviving mutant — the records an agent or reviewer acts on:
 
 Both use the lean shape `{ subject, file, line }`. `no_coverage` is a genuine coverage gap; `uncapturable`
 means the test that should cover the line errored while capturing coverage (fix the harness, not the test).
+
+### `no_verdict[]` (array of object)
+
+Every mutant that was attempted and produced no verdict: `{ subject, file, line, id, status, details }`.
+`status` is `"error"`, `"timeout"` or `"uncapturable"`, and its length equals `summary.no_verdict`.
+`details` carries the cause for `"error"`; it is `null` for the other two, where the status is the whole
+story. A failure before the mutant could be forked has no subject, so `subject`, `file`, `line` and `id`
+are `null` there — so `id` is not a reliable join key in this array, unlike in `survivors[]`.
+
+These mutants are excluded from the score's denominator, so a broken harness raises the score rather
+than lowering it. That is why `--threshold` gates on completeness as well.
 
 ### `ignored[]` (array of object)
 

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -54,14 +54,19 @@ module Mutineer
         out.print rendered
       end
 
-      # Here rather than in the human renderer: --format json is the documented CI
-      # path, and a run that exits 1 must say why on every format, not only the one
-      # a person reads.
-      return unless threshold&.positive? && broken_share_exceeded?
+      # Both ways a run can fail the gate on completeness, said here rather than in
+      # the human renderer: --format json is the documented CI path, and a run that
+      # exits 1 must say why on every format, not only the one a person reads.
+      return unless threshold&.positive?
 
-      err.puts "[mutineer] #{no_verdict_ratio}: #{broken_counts_detail}. The score covers " \
-               "only part of the run, so the --threshold gate fails. See no_verdict[] in " \
-               "--format json for the cause of each."
+      if @agg.mutation_score.nil? && broken_nil_score?
+        err.puts "[mutineer] nothing could be scored (#{broken_counts_detail}), so the " \
+                 "--threshold gate fails. See no_verdict[] in --format json for the cause of each."
+      elsif broken_share_exceeded?
+        err.puts "[mutineer] #{no_verdict_ratio}: #{broken_counts_detail}. The score covers " \
+                 "only part of the run, so the --threshold gate fails. See no_verdict[] in " \
+                 "--format json for the cause of each."
+      end
     end
 
     # Renders the human report.
@@ -164,7 +169,7 @@ module Mutineer
         # worker finish order in the output and break the byte-stability promise.
         no_verdict: @agg.results.select { |r| r.error? || r.timeout? || r.uncapturable? }
                         .map { |r| no_verdict_json(r) }
-                        .sort_by { |h| [h[:file].to_s, h[:line].to_i, h[:id].to_s, h[:status].to_s] },
+                        .sort_by { |h| [h[:file].to_s, h[:line].to_i, h[:id].to_s, h[:status].to_s, h[:details].to_s] },
         # Equivalent mutants the user suppressed: emitted with their stable id so
         # the user can audit what is silenced (and copy ids for survivors they
         # want to add). Excluded from the score; never in `survivors`.
@@ -455,10 +460,10 @@ module Mutineer
                  "#{@agg.ignored_count} ignored excluded"
       if score.nil?
         out.puts "Mutation score: N/A  (no covered mutants)"
-        if broken_nil_score?
-          err.puts "[mutineer] no covered mutations (#{broken_counts_detail}); " \
-                   "threshold gate fails under a positive --threshold (broken harness)."
-        else
+        # Only the benign case here: the gate-failure explanation is emitted once
+        # from {report}, for every format, so it cannot be said twice or only to
+        # the reader of the human report.
+        unless broken_nil_score?
           err.puts "[mutineer] no covered mutations; mutation score is N/A and the threshold check is skipped."
         end
       else
@@ -499,12 +504,10 @@ module Mutineer
     # skipped-invalid and ignored mutants were never attempted, so counting them
     # would dilute the share and let a broken run slip under the limit.
     #
-    # skipped-invalid is excluded from BOTH sides on purpose. It means Mutineer
-    # generated a mutant that did not re-parse and correctly declined to run it —
-    # a validity outcome, not a broken harness, and a few are normal for some
-    # operators. The cost is that a run which is overwhelmingly skipped still
-    # scores on what little ran; that is a different failure (a bad operator, ours
-    # not the user's) and wants its own signal rather than this gate's.
+    # skipped-invalid is excluded from both sides: it means a mutant did not
+    # re-parse and was correctly never run, which is a validity outcome rather
+    # than a broken harness. Cost: an overwhelmingly-skipped run still scores on
+    # what little ran; that is our operator misbehaving and wants its own signal.
     #
     # @api private
     # @return [Integer] killed + survived + no-verdict.

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -20,6 +20,11 @@ module Mutineer
     # a different number yet.
     BROKEN_SHARE_LIMIT = 0.10
 
+    # A share alone gives a small run no tolerance at all: on a `--since` PR that
+    # yields 8 mutants, one timeout is 12.5%. README recommends exactly that
+    # workflow, so one bad mutant never fails the gate on its own, at any size.
+    BROKEN_FLOOR = 1
+
     def initialize(aggregate, source_map)
       @agg = aggregate
       @source_map = source_map
@@ -48,6 +53,15 @@ module Mutineer
       else
         out.print rendered
       end
+
+      # Here rather than in the human renderer: --format json is the documented CI
+      # path, and a run that exits 1 must say why on every format, not only the one
+      # a person reads.
+      return unless threshold&.positive? && broken_share_exceeded?
+
+      err.puts "[mutineer] #{no_verdict_ratio}: #{broken_counts_detail}. The score covers " \
+               "only part of the run, so the --threshold gate fails. See no_verdict[] in " \
+               "--format json for the cause of each."
     end
 
     # Renders the human report.
@@ -125,6 +139,8 @@ module Mutineer
           skipped_invalid: @agg.skipped_invalid_count,
           errored: @agg.errored_count, timeout: @agg.timeout_count,
           ignored: @agg.ignored_count,
+          # The gate is computed from these two, so a consumer never re-derives them.
+          attempted: attempted_count, no_verdict: no_verdict_count,
           score: score
         },
         survivors: @agg.surviving_mutants.map { |r| survivor_json(r) }
@@ -134,13 +150,17 @@ module Mutineer
         # Same shape as no_coverage; additive key.
         uncapturable: @agg.results.select(&:uncapturable?).map { |r| no_coverage_json(r) }
                           .sort_by { |h| [h[:file], h[:line]] },
-        # Mutants that were attempted and produced no verdict. `details` carries the
-        # cause (a daemon crash, a timeout); until this key existed it was built and
-        # never rendered, so a broken run looked like a weak suite in every format.
-        # to_s/to_i because a pre-fork failure carries no subject or mutation, so
-        # its file and line are null and would not compare against a real entry's.
-        errored: @agg.results.select { |r| r.error? || r.timeout? }.map { |r| errored_json(r) }
-                     .sort_by { |h| [h[:file].to_s, h[:line].to_i] },
+        # Every mutant that was attempted and produced no verdict, whatever the
+        # reason — the set the --threshold completeness gate counts. Named for the
+        # condition rather than one status, because summary.errored means :error
+        # alone and a key that reconciled with neither would be worse. `details`
+        # carries the cause where there is one. Uncapturable mutants also appear in
+        # uncapturable[]; that key keeps its lean shape for existing consumers.
+        # to_s/to_i because a pre-fork failure has no subject, so its file and line
+        # are null and would not compare against a real entry.
+        no_verdict: @agg.results.select { |r| r.error? || r.timeout? || r.uncapturable? }
+                        .map { |r| no_verdict_json(r) }
+                        .sort_by { |h| [h[:file].to_s, h[:line].to_i] },
         # Equivalent mutants the user suppressed: emitted with their stable id so
         # the user can audit what is silenced (and copy ids for survivors they
         # want to add). Excluded from the score; never in `survivors`.
@@ -376,15 +396,15 @@ module Mutineer
       }
     end
 
-    # An entry under the JSON `errored:` key: an attempted mutant with no verdict.
+    # An entry under the JSON `no_verdict:` key: an attempted mutant with no verdict.
     # A pre-fork failure has no subject or mutation attached, so those degrade to
     # nulls rather than dropping the entry — the count must still reconcile with
-    # `summary.errored` + `summary.timeout`.
+    # `summary.no_verdict`.
     #
     # @api private
     # @param result [Mutineer::Result] an errored or timed-out result.
-    # @return [Hash] errored JSON object.
-    def errored_json(result)
+    # @return [Hash] no-verdict JSON object.
+    def no_verdict_json(result)
       file = result.subject&.file
       line =
         if result.mutation && file
@@ -432,17 +452,13 @@ module Mutineer
       if score.nil?
         out.puts "Mutation score: N/A  (no covered mutants)"
         if broken_nil_score?
-          err.puts "[mutineer] no covered mutations (#{broken_nil_score_detail}); " \
+          err.puts "[mutineer] no covered mutations (#{broken_counts_detail}); " \
                    "threshold gate fails under a positive --threshold (broken harness)."
         else
           err.puts "[mutineer] no covered mutations; mutation score is N/A and the threshold check is skipped."
         end
       else
         out.puts "Mutation score: #{score}%  (killed / (killed + survived); #{excluded})"
-        if broken_share_exceeded?
-          err.puts "[mutineer] #{broken_nil_score_detail}: too much of the run produced no " \
-                   "verdict, so this score covers only part of it; threshold gate fails."
-        end
       end
     end
 
@@ -462,16 +478,46 @@ module Mutineer
     # @api private
     # @return [Boolean] true when too much of the run failed to produce a verdict.
     def broken_share_exceeded?
-      broken = @agg.errored_count + @agg.timeout_count + @agg.uncapturable_count
-      attempted = @agg.killed_count + @agg.survived_count + broken
-      attempted.positive? && broken > attempted * BROKEN_SHARE_LIMIT
+      attempted = attempted_count
+      attempted.positive? && no_verdict_count > BROKEN_FLOOR &&
+        no_verdict_count > attempted * BROKEN_SHARE_LIMIT
     end
 
-    # Human-readable counts for a broken nil-score run.
+    # Mutants that were attempted and produced no verdict, whatever the reason.
+    #
+    # @api private
+    # @return [Integer] errored + timed out + uncapturable.
+    def no_verdict_count
+      @agg.errored_count + @agg.timeout_count + @agg.uncapturable_count
+    end
+
+    # Mutants that were actually run. Deliberately not `total`: no_coverage,
+    # skipped-invalid and ignored mutants were never attempted, so counting them
+    # would dilute the share and let a broken run slip under the limit.
+    #
+    # @api private
+    # @return [Integer] killed + survived + no-verdict.
+    def attempted_count
+      @agg.killed_count + @agg.survived_count + no_verdict_count
+    end
+
+    # The sentence both the verdict line and the stderr note are built from, so a
+    # user cannot read one number in the report and a different one beside it.
+    #
+    # @api private
+    # @return [String] e.g. "90 of 100 attempted mutants produced no verdict (90.0%, limit 10%)".
+    def no_verdict_ratio
+      pct = (no_verdict_count * 100.0 / attempted_count).round(1)
+      "#{no_verdict_count} of #{attempted_count} attempted mutants produced no verdict " \
+        "(#{pct}%, limit #{(BROKEN_SHARE_LIMIT * 100).round}%)"
+    end
+
+    # Human-readable counts of the states that produced no verdict. Used by both
+    # the nil-score message and the completeness gate, so they agree.
     #
     # @api private
     # @return [String]
-    def broken_nil_score_detail
+    def broken_counts_detail
       parts = []
       parts << "#{@agg.errored_count} errored" if @agg.errored_count.positive?
       parts << "#{@agg.timeout_count} timeout" if @agg.timeout_count.positive?
@@ -564,13 +610,17 @@ module Mutineer
       score = @agg.mutation_score
       if score.nil?
         if broken_nil_score?
-          out.puts "FAILED: no covered mutants (#{broken_nil_score_detail}); " \
+          out.puts "FAILED: no covered mutants (#{broken_counts_detail}); " \
                    "threshold #{threshold}% cannot pass with a broken harness"
         end
         return
       end
 
-      if score >= threshold
+      # Same rule as exit_code, or the report says PASSED on a run that exits 1 —
+      # and with --output that wrong verdict is what gets archived.
+      if broken_share_exceeded?
+        out.puts "FAILED: #{no_verdict_ratio}; #{score}% covers only part of the run"
+      elsif score >= threshold
         out.puts "PASSED: #{score}% >= threshold #{threshold}%"
       else
         out.puts "FAILED: #{score}% < threshold #{threshold}%"

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -157,10 +157,14 @@ module Mutineer
         # carries the cause where there is one. Uncapturable mutants also appear in
         # uncapturable[]; that key keeps its lean shape for existing consumers.
         # to_s/to_i because a pre-fork failure has no subject, so its file and line
-        # are null and would not compare against a real entry.
+        # are null and would not compare against a real entry. id and status extend
+        # the key to a total order: these entries collide on (file, line) far more
+        # than survivors do — several mutants on one crashy line, every pre-fork
+        # entry on ("", 0) — and sort_by is not stable, so equal keys would leave
+        # worker finish order in the output and break the byte-stability promise.
         no_verdict: @agg.results.select { |r| r.error? || r.timeout? || r.uncapturable? }
                         .map { |r| no_verdict_json(r) }
-                        .sort_by { |h| [h[:file].to_s, h[:line].to_i] },
+                        .sort_by { |h| [h[:file].to_s, h[:line].to_i, h[:id].to_s, h[:status].to_s] },
         # Equivalent mutants the user suppressed: emitted with their stable id so
         # the user can audit what is silenced (and copy ids for survivors they
         # want to add). Excluded from the score; never in `survivors`.
@@ -494,6 +498,13 @@ module Mutineer
     # Mutants that were actually run. Deliberately not `total`: no_coverage,
     # skipped-invalid and ignored mutants were never attempted, so counting them
     # would dilute the share and let a broken run slip under the limit.
+    #
+    # skipped-invalid is excluded from BOTH sides on purpose. It means Mutineer
+    # generated a mutant that did not re-parse and correctly declined to run it —
+    # a validity outcome, not a broken harness, and a few are normal for some
+    # operators. The cost is that a run which is overwhelmingly skipped still
+    # scores on what little ran; that is a different failure (a bad operator, ours
+    # not the user's) and wants its own signal rather than this gate's.
     #
     # @api private
     # @return [Integer] killed + survived + no-verdict.

--- a/lib/mutineer/reporter.rb
+++ b/lib/mutineer/reporter.rb
@@ -14,6 +14,12 @@ module Mutineer
   # `source_map` is { file_path => raw source string }, used to extract the
   # containing source line for each survivor diff.
   class Reporter
+    # Share of attempted mutants that may produce no verdict before `--threshold`
+    # stops trusting the score. A handful of flaky mutants in a large run is noise;
+    # a mostly-broken run is not a score. Deliberately not a flag: no one has needed
+    # a different number yet.
+    BROKEN_SHARE_LIMIT = 0.10
+
     def initialize(aggregate, source_map)
       @agg = aggregate
       @source_map = source_map
@@ -85,6 +91,11 @@ module Mutineer
         return 0 # pure no_coverage / ignored / empty — gate skipped
       end
 
+      # A score computed over a small slice of what was attempted is not this
+      # suite's score. Without this, 90 errored mutants and 10 that ran (9 killed)
+      # reports 90% and exits 0, so CI cannot tell a complete run from a broken one.
+      return 1 if broken_share_exceeded?
+
       score >= threshold ? 0 : 1
     end
 
@@ -106,7 +117,7 @@ module Mutineer
       score = @agg.mutation_score
 
       doc = {
-        schema_version: "1.1",
+        schema_version: "1.2",
         summary: {
           total: @agg.total, killed: killed, survived: survived,
           no_coverage: @agg.no_coverage_count,
@@ -123,6 +134,13 @@ module Mutineer
         # Same shape as no_coverage; additive key.
         uncapturable: @agg.results.select(&:uncapturable?).map { |r| no_coverage_json(r) }
                           .sort_by { |h| [h[:file], h[:line]] },
+        # Mutants that were attempted and produced no verdict. `details` carries the
+        # cause (a daemon crash, a timeout); until this key existed it was built and
+        # never rendered, so a broken run looked like a weak suite in every format.
+        # to_s/to_i because a pre-fork failure carries no subject or mutation, so
+        # its file and line are null and would not compare against a real entry's.
+        errored: @agg.results.select { |r| r.error? || r.timeout? }.map { |r| errored_json(r) }
+                     .sort_by { |h| [h[:file].to_s, h[:line].to_i] },
         # Equivalent mutants the user suppressed: emitted with their stable id so
         # the user can audit what is silenced (and copy ids for survivors they
         # want to add). Excluded from the score; never in `survivors`.
@@ -134,7 +152,7 @@ module Mutineer
                         .sort_by { |h| h[:file] }
       }
       # Additive baseline-delta block, present only with --baseline. Existing
-      # consumers ignore the extra key; schema_version stays 1.1.
+      # consumers ignore the extra key; it does not move schema_version on its own.
       doc[:baseline] = baseline_json(baseline) if baseline
       "#{JSON.generate(doc)}\n"
     end
@@ -358,6 +376,31 @@ module Mutineer
       }
     end
 
+    # An entry under the JSON `errored:` key: an attempted mutant with no verdict.
+    # A pre-fork failure has no subject or mutation attached, so those degrade to
+    # nulls rather than dropping the entry — the count must still reconcile with
+    # `summary.errored` + `summary.timeout`.
+    #
+    # @api private
+    # @param result [Mutineer::Result] an errored or timed-out result.
+    # @return [Hash] errored JSON object.
+    def errored_json(result)
+      file = result.subject&.file
+      line =
+        if result.mutation && file
+          source = @source_map[file] || File.read(file)
+          source.byteslice(0, result.mutation.start_offset).count("\n") + 1
+        end
+      {
+        subject: result.subject&.qualified_name,
+        file: file,
+        line: line,
+        id: result.id,
+        status: result.status.to_s,
+        details: result.details
+      }
+    end
+
     # Writes the summary block.
     #
     # @param out [IO] output stream.
@@ -396,6 +439,10 @@ module Mutineer
         end
       else
         out.puts "Mutation score: #{score}%  (killed / (killed + survived); #{excluded})"
+        if broken_share_exceeded?
+          err.puts "[mutineer] #{broken_nil_score_detail}: too much of the run produced no " \
+                   "verdict, so this score covers only part of it; threshold gate fails."
+        end
       end
     end
 
@@ -406,6 +453,18 @@ module Mutineer
     def broken_nil_score?
       @agg.total.positive? &&
         (@agg.errored_count + @agg.timeout_count + @agg.uncapturable_count).positive?
+    end
+
+    # Mutants that were attempted but produced no verdict, over everything
+    # attempted. Above the limit the score describes too small a slice of the run
+    # to gate on. A few flaky mutants in a large run stay under it.
+    #
+    # @api private
+    # @return [Boolean] true when too much of the run failed to produce a verdict.
+    def broken_share_exceeded?
+      broken = @agg.errored_count + @agg.timeout_count + @agg.uncapturable_count
+      attempted = @agg.killed_count + @agg.survived_count + broken
+      attempted.positive? && broken > attempted * BROKEN_SHARE_LIMIT
     end
 
     # Human-readable counts for a broken nil-score run.

--- a/test/baseline_test.rb
+++ b/test/baseline_test.rb
@@ -35,6 +35,8 @@ class BaselineTest < Minitest::Test
   # A baseline doc (a prior --format json run) carrying the given survivor ids.
   def baseline_doc(ids, score: nil)
     {
+      # Deliberately an older schema: a baseline written by a prior version must
+      # still be readable, per the "accept any 1.x" contract in docs/json-schema.md.
       "schema_version" => "1.1",
       "summary" => { "score" => score },
       "survivors" => ids.map do |id|
@@ -167,7 +169,7 @@ class BaselineTest < Minitest::Test
     results = [Mutineer::Result.killed, survivor("ccc")]
     doc = JSON.parse(render(results, base.diff(agg(*results)), format: "json"))
 
-    assert_equal "1.1", doc["schema_version"] # schema unchanged
+    assert_equal "1.2", doc["schema_version"] # the baseline block alone does not move it
     assert doc["baseline"]["regressed"]
     assert_equal 1, doc["baseline"]["new_survivors"].size
     assert_equal "ccc", doc["baseline"]["new_survivors"].first["id"]

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -171,7 +171,7 @@ class CliTest < Minitest::Test
                               "--format", "json", "--output", "report.json", chdir: proj)
       assert_equal 0, status.exitstatus
       doc = JSON.parse(File.read(File.join(proj, "report.json")))
-      assert_equal "1.1", doc["schema_version"]
+      assert_equal "1.2", doc["schema_version"]
       assert_equal 100.0, doc["summary"]["score"]
     end
   end
@@ -252,7 +252,7 @@ class CliTest < Minitest::Test
       out, _, status = mutineer("run", "lib", "--format", "json", chdir: proj)
       assert_equal 0, status.exitstatus
       doc = JSON.parse(out)
-      assert_equal "1.1", doc["schema_version"]
+      assert_equal "1.2", doc["schema_version"]
       per = doc["per_source"].sort_by { |h| h["file"] }
       assert_equal ["lib/calc.rb", "lib/greeter.rb"], per.map { |h| h["file"] }
       assert_equal 100.0, per.find { |h| h["file"] == "lib/greeter.rb" }["score"]

--- a/test/equivalent_mutant_test.rb
+++ b/test/equivalent_mutant_test.rb
@@ -106,7 +106,7 @@ class EquivalentMutantTest < Minitest::Test
                                    tests: ["test/fixtures/calculator_weak_test.rb"])
     doc = render_json(agg, source_map)
 
-    assert_equal "1.1", doc["schema_version"]
+    assert_equal "1.2", doc["schema_version"]
     assert_equal 2, doc["summary"]["survived"]
     assert_equal 0, doc["summary"]["ignored"]
     ids = doc["survivors"].map { |s| s["id"] }

--- a/test/json_reporter_test.rb
+++ b/test/json_reporter_test.rb
@@ -34,11 +34,36 @@ class JsonReporterTest < Minitest::Test
 
   def test_valid_json_with_summary_and_score
     doc = render([Mutineer::Result.killed, survivor])
-    assert_equal "1.1", doc["schema_version"]
+    assert_equal "1.2", doc["schema_version"]
     assert_equal 1, doc["summary"]["killed"]
     assert_equal 1, doc["summary"]["survived"]
     assert_equal 50.0, doc["summary"]["score"]
     assert doc["summary"].key?("timeout")
+  end
+
+  # Until this key existed, Result#details was built and rendered nowhere, so a
+  # daemon crash reached the user as nothing but a bump in the errored count.
+  def test_errored_entries_carry_their_cause
+    doc = render([Mutineer::Result.error("daemon worker crashed: Errno::EPIPE"),
+                  Mutineer::Result.timeout, Mutineer::Result.killed])
+    entries = doc["errored"]
+
+    assert_equal 2, entries.size
+    assert_equal doc["summary"]["errored"] + doc["summary"]["timeout"], entries.size
+    crash = entries.find { |e| e["status"] == "error" }
+    assert_match(/daemon worker crashed/, crash["details"])
+    assert_equal "timeout", entries.find { |e| e["status"] == "timeout" }["status"]
+  end
+
+  # A pre-fork failure has no subject or mutation, so its file and line are null.
+  # It must still appear rather than break the sort or vanish from the array.
+  def test_errored_entry_without_a_subject_still_appears
+    doc = render([Mutineer::Result.error("boot failed"), survivor])
+    entry = doc["errored"].first
+
+    assert_nil entry["file"]
+    assert_nil entry["line"]
+    assert_equal "boot failed", entry["details"]
   end
 
   def test_survivor_entry_has_all_keys_and_diff

--- a/test/json_reporter_test.rb
+++ b/test/json_reporter_test.rb
@@ -80,6 +80,21 @@ class JsonReporterTest < Minitest::Test
     assert_equal 1, doc["uncapturable"].size
   end
 
+  # Entries collide on (file, line) far more than survivors do — every pre-fork
+  # entry lands on the same key — and sort_by is not stable, so without id and
+  # status in the key the array would carry worker finish order between runs.
+  def test_no_verdict_order_is_stable_for_colliding_entries
+    a = Mutineer::Result.error("one").with(subject: subject, mutation: mutation_at(">=", ">", :comparison), id: "aaa")
+    b = Mutineer::Result.error("two").with(subject: subject, mutation: mutation_at(">=", ">", :comparison), id: "bbb")
+    pre1 = Mutineer::Result.error("boot a")
+    pre2 = Mutineer::Result.timeout
+
+    forward = render([a, b, pre1, pre2])["no_verdict"]
+    reverse = render([pre2, pre1, b, a])["no_verdict"]
+
+    assert_equal forward, reverse, "the array must not carry input order between runs"
+  end
+
   # The two figures the completeness gate is computed from, so a consumer never has
   # to re-derive which statuses count.
   def test_summary_carries_the_figures_the_gate_uses

--- a/test/json_reporter_test.rb
+++ b/test/json_reporter_test.rb
@@ -43,13 +43,13 @@ class JsonReporterTest < Minitest::Test
 
   # Until this key existed, Result#details was built and rendered nowhere, so a
   # daemon crash reached the user as nothing but a bump in the errored count.
-  def test_errored_entries_carry_their_cause
+  def test_no_verdict_entries_carry_their_cause
     doc = render([Mutineer::Result.error("daemon worker crashed: Errno::EPIPE"),
                   Mutineer::Result.timeout, Mutineer::Result.killed])
-    entries = doc["errored"]
+    entries = doc["no_verdict"]
 
     assert_equal 2, entries.size
-    assert_equal doc["summary"]["errored"] + doc["summary"]["timeout"], entries.size
+    assert_equal doc["summary"]["no_verdict"], entries.size
     crash = entries.find { |e| e["status"] == "error" }
     assert_match(/daemon worker crashed/, crash["details"])
     assert_equal "timeout", entries.find { |e| e["status"] == "timeout" }["status"]
@@ -57,13 +57,38 @@ class JsonReporterTest < Minitest::Test
 
   # A pre-fork failure has no subject or mutation, so its file and line are null.
   # It must still appear rather than break the sort or vanish from the array.
-  def test_errored_entry_without_a_subject_still_appears
+  def test_no_verdict_entry_without_a_subject_still_appears
     doc = render([Mutineer::Result.error("boot failed"), survivor])
-    entry = doc["errored"].first
+    entry = doc["no_verdict"].first
 
     assert_nil entry["file"]
     assert_nil entry["line"]
     assert_equal "boot failed", entry["details"]
+  end
+
+  # The gate counts uncapturable, and the docs send the user to no_verdict[] to see
+  # what failed, so a run failed purely by uncapturable mutants must not find it empty.
+  def test_no_verdict_includes_uncapturable_because_the_gate_counts_it
+    unc = Mutineer::Result.uncapturable.with(subject: subject,
+                                             mutation: mutation_at("100", "0", :literal_mutation))
+    doc = render([unc, Mutineer::Result.killed])
+
+    assert_equal 1, doc["no_verdict"].size
+    assert_equal "uncapturable", doc["no_verdict"].first["status"]
+    assert_equal doc["summary"]["no_verdict"], doc["no_verdict"].size
+    # It keeps its own lean array too, for consumers that already read that key.
+    assert_equal 1, doc["uncapturable"].size
+  end
+
+  # The two figures the completeness gate is computed from, so a consumer never has
+  # to re-derive which statuses count.
+  def test_summary_carries_the_figures_the_gate_uses
+    uncovered = Mutineer::Result.no_coverage.with(subject: subject,
+                                                  mutation: mutation_at("100", "0", :literal_mutation))
+    doc = render([Mutineer::Result.error("x"), Mutineer::Result.killed, uncovered])
+
+    assert_equal 2, doc["summary"]["attempted"] # no_coverage was never attempted
+    assert_equal 1, doc["summary"]["no_verdict"]
   end
 
   def test_survivor_entry_has_all_keys_and_diff

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -87,6 +87,42 @@ class ReporterTest < Minitest::Test
     assert_equal 1, r.exit_code(threshold: 80.0)
   end
 
+  # The report's verdict line and the exit code must come from one rule, or a run
+  # that exits 1 prints PASSED — and with --output that is what gets archived.
+  def test_verdict_line_agrees_with_the_exit_code
+    results = Array.new(90) { Mutineer::Result.error("crash") } +
+              Array.new(9) { Mutineer::Result.killed } + [survivor_result]
+    out = StringIO.new
+    r = reporter(results)
+    r.human_report(out, StringIO.new, 80.0)
+
+    assert_equal 1, r.exit_code(threshold: 80.0)
+    refute_match(/PASSED/, out.string, "the report said PASSED on a run that exits 1")
+    assert_match(/FAILED: 90 of 100 attempted/, out.string)
+  end
+
+  # --format json is the documented CI path, so the reason must not live only in
+  # the renderer a person reads.
+  def test_the_gate_explains_itself_on_every_format
+    results = Array.new(90) { Mutineer::Result.error("crash") } +
+              Array.new(9) { Mutineer::Result.killed } + [survivor_result]
+
+    %w[json human].each do |format|
+      err = StringIO.new
+      reporter(results).report(out: StringIO.new, err: err, threshold: 80.0, format: format)
+
+      assert_match(/90 of 100 attempted mutants produced no verdict/, err.string, "#{format}: no reason given")
+      assert_match(/limit 10%/, err.string, "#{format}: never states the rule")
+    end
+  end
+
+  # A --since PR run can yield a handful of mutants, where one timeout is over 10%.
+  # One bad mutant must never fail the gate on its own, at any run size.
+  def test_a_single_broken_mutant_never_fails_the_gate
+    assert_equal 0, reporter([Mutineer::Result.timeout] + Array.new(4) { Mutineer::Result.killed })
+      .exit_code(threshold: 80.0)
+  end
+
   # The flip side: a couple of flaky mutants in a large run must not turn CI red.
   def test_exit_code_tolerates_a_few_broken_mutants
     results = Array.new(3) { Mutineer::Result.error("flake") } +

--- a/test/reporter_test.rb
+++ b/test/reporter_test.rb
@@ -75,6 +75,37 @@ class ReporterTest < Minitest::Test
     assert_equal 0, r.exit_code(threshold: 80.0) # 80.0 >= 80.0
   end
 
+  # A score over a slice of the run is not this suite's score: 90 errored and 10
+  # run (9 killed) reads 90% and used to exit 0, so CI could not tell a complete
+  # run from a broken one.
+  def test_exit_code_fails_when_most_attempted_mutants_produced_no_verdict
+    results = Array.new(90) { Mutineer::Result.error("daemon worker crashed") } +
+              Array.new(9) { Mutineer::Result.killed } + [Mutineer::Result.survived]
+    r = reporter(results)
+
+    assert_equal 90.0, r.instance_variable_get(:@agg).mutation_score
+    assert_equal 1, r.exit_code(threshold: 80.0)
+  end
+
+  # The flip side: a couple of flaky mutants in a large run must not turn CI red.
+  def test_exit_code_tolerates_a_few_broken_mutants
+    results = Array.new(3) { Mutineer::Result.error("flake") } +
+              Array.new(900) { Mutineer::Result.killed } +
+              Array.new(97) { Mutineer::Result.survived }
+
+    assert_equal 0, reporter(results).exit_code(threshold: 80.0)
+  end
+
+  # Timeouts and uncapturable count toward the same limit — all three mean the
+  # mutant was attempted and no verdict came back.
+  def test_exit_code_counts_timeouts_and_uncapturable_as_broken
+    results = Array.new(5) { Mutineer::Result.timeout } +
+              Array.new(5) { Mutineer::Result.uncapturable } +
+              Array.new(10) { Mutineer::Result.killed }
+
+    assert_equal 1, reporter(results).exit_code(threshold: 50.0)
+  end
+
   def test_exit_code_nil_score_pure_no_coverage_skips_gate
     assert_equal 0, reporter([Mutineer::Result.no_coverage]).exit_code(threshold: 80.0)
   end


### PR DESCRIPTION
Closes #78. Found during the #58 review, and the last honest-score hole from that pass.

## What

A mutation score is `killed / (killed + survived)`. Mutants that error, time out or come back uncapturable are excluded from that denominator — so a **broken harness raised the score instead of lowering it**, and `Reporter#exit_code` only noticed when the score was `nil`.

Ninety errored mutants and ten that ran (nine killed) reported **90% and exited 0**. A CI job reading the exit code could not tell a complete run from a mostly-broken one.

Past 10% of attempted mutants producing no verdict, a positive `--threshold` now exits 1 whatever the score, and every surface says why.

## The rule

```
no_verdict = errored + timeout + uncapturable
attempted  = killed + survived + no_verdict
fail when  no_verdict > 1  AND  no_verdict > attempted * 0.10
```

The floor matters as much as the share. README recommends `--since origin/<base>` for PR CI, and a one-file PR can yield a handful of mutants, where a single timeout is over 10%. One bad mutant never gates, at any run size. Three of a thousand stays green; two of eleven does not.

`skipped_invalid` is deliberately in neither the numerator nor the denominator, and that decision is now written down with its cost: a run that is overwhelmingly skipped still scores on what little ran. That failure is one of our operators emitting invalid code rather than the user's harness, and wants its own signal rather than this gate's.

## Visibility

`Result#details` was built and rendered in **no format at all**, so a daemon crash reached the user as nothing but a larger errored count. The JSON report gains `no_verdict[]` (`schema_version` 1.2) carrying `status` and `details`, plus `summary.attempted` and `summary.no_verdict` so a consumer never re-derives which statuses count.

Named for the condition rather than a status because `summary.errored` means `:error` alone: an array called `errored` that held three statuses, or reconciled with nothing, would be worse. Renaming was free — it was never released.

## What review changed

The first version of this was worse than the bug in one respect, and two reviewers caught it independently:

- **The report printed `PASSED` while the process exited 1.** `verdict` branched on score alone. With `--output FILE`, that wrong verdict is what gets archived — the same dishonest-signal class this PR exists to fix.
- **`--format json` failed silently.** The reason lived only in the human renderer, so the documented CI path (and this repo's own Action, which defaults to json) exited 1 with an empty stderr and a document showing a healthy score.
- **The gate counted `uncapturable`, the array excluded it**, and the docs pointed at that array as the explanation.
- **`no_verdict[]` order followed worker finish order.** Entries collide on `(file, line)` far more than survivors, and `sort_by` is not stable, so diffing two reports of the same broken run showed phantom churn against the file's own byte-stability promise.

## Testing

Every guard verified to fail when its protection is removed:

- the verdict line agrees with the exit code
- the gate explains itself on `--format json` and `human`
- one broken mutant never gates; three in a thousand stay green; two in eleven do not
- timeouts and uncapturable count toward the same limit
- `no_verdict[]` includes uncapturable and reconciles with `summary.no_verdict`
- its order is identical for reversed input

`rake test` 432 runs / 1237 assertions, `rake test:daemon` 14 runs, `yard:strict` 100%, cubic clean.

## Follow-up filed

**#82** — this contract lives in six hand-maintained copies (README, `docs/json-schema.md`, `docs/json-schema.html`, `docs/llms-full.txt`, `docs/agentic-coding.md`, `action.yml`). Five were missed on the first pass here. `docs/llms-full.txt` is what the site serves to agents, so a stale copy teaches every agent the wrong contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfCKGYtEpcYLtp71Rsqf3h
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidteren/mutineer/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `--threshold` to require a complete run, not just a high score. CI now fails if nothing could be scored and something broke, or if >1 no-verdict mutants exceed 10% of attempted; every format explains why.

- **Bug Fixes**
  - Gate on completeness: fail when either (a) nothing could be scored and something broke, or (b) `errored + timeout + uncapturable` > 1 and > 10% of `attempted = killed + survived + no_verdict`. Pure `no_coverage` nil-score still skips; the “>1” floor applies only when a score exists.
  - Verdict line matches the exit code; the gate reason is emitted once per run across `human` and `json`.
  - Deterministic `no_verdict[]` order via `(file, line, id, status, details)` for byte-identical output.
  - Docs (`README`, `docs/json-schema.*`, `docs/llms-full.txt`, `docs/agentic-coding.md`, `action.yml`) updated to state both completeness cases, the floor, and the 10% rule.

- **New Features**
  - JSON (`schema_version` "1.2"): add `no_verdict[]` with `status` and `details`; include pre-fork failures with null `subject`/`file`/`line`.
  - Add `summary.attempted` and `summary.no_verdict` so consumers never re-derive the gate inputs.
  - Keep `uncapturable[]` as a lean list; those entries also appear in `no_verdict[]`.

<sup>Written for commit e600902f85e8dcfb056655ae2562523062b4adea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/davidteren/mutineer/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

